### PR TITLE
Document validation fields

### DIFF
--- a/web/docs/templates/templates.md
+++ b/web/docs/templates/templates.md
@@ -23,7 +23,13 @@ On top of the usual schema, we added some more fields to help our users get as m
 
 :::
 
-## Helm schema
+## Helm schema validation
+
+:::info
+
+Available from [ v0.0.1-alpha.7 ](https://github.com/cyclops-ui/cyclops/releases/tag/v0.0.1-alpha.7)
+
+:::
 
 As mentioned, Cyclops renders its UI based on the JSON schema. JSON schema provides some fields to help with validations. Those fields are listed below, as well as whether or not Cyclops currently supports those.
 

--- a/web/docs/templates/templates.md
+++ b/web/docs/templates/templates.md
@@ -5,6 +5,8 @@ form based on the `values.schema.json` file. That file is used to define values 
 about it and learn how to create one by following [Helm docs](https://helm.sh/docs/topics/charts/#schema-files). The 
 schema is represented as a [JSON Schema](https://json-schema.org/)
 
+You can find a list of all the fields you can set below for each field type.
+
 On top of the usual schema, we added some more fields to help our users get as much from the UI.
 
 | Name            | Type         | Description                                                                                                                                                                       | Valid input                                                      |
@@ -20,3 +22,32 @@ On top of the usual schema, we added some more fields to help our users get as m
 - [Helm chart dependencies are not yet supported](https://github.com/cyclops-ui/cyclops/issues/75)
 
 :::
+
+## Helm schema
+
+As mentioned, Cyclops renders its UI based on the JSON schema. JSON schema provides some fields to help with validations. Those fields are listed below, as well as whether or not Cyclops currently supports those.
+
+### Strings
+
+[JSON schema reference](https://json-schema.org/understanding-json-schema/reference/string)
+
+| Name        | Description                                                                                        | Supported          | 
+|:------------|----------------------------------------------------------------------------------------------------|--------------------|
+| `minLength` | minimum length of the field value                                                                  | :white_check_mark: |
+| `maxLength` | minimum length of the field value                                                                  | :white_check_mark: | 
+| `pattern`   | restrict a string to a particular regular expression                                               | :x:                |
+| `format`    | allows for basic semantic identification of certain kinds of string values that are commonly used  | :x:                |
+
+<hr/>
+
+### Numeric
+
+[JSON schema reference](https://json-schema.org/understanding-json-schema/reference/numeric)
+
+| Name               | Description                         | Supported          | 
+|:-------------------|-------------------------------------|--------------------|
+| `minimum`          | minimum field value                 | :white_check_mark: |
+| `maximum`          | maximum field value                 | :white_check_mark: |
+| `exclusiveMinimum` | exclusive minimum field value       | :x:                |
+| `exclusiveMaximum` | exclusive minimum field value       | :x:                |
+| `multipleOf`       | field value has to be a multiple of | :white_check_mark: |


### PR DESCRIPTION
Adds documentation on validation fields in JSON schema. Should not be deployed before there is a created release supporting validations.