### PR TITLE
[UI] remove unused code and center Cyclops&Logo in the corner

### DIFF
--- a/cyclops-ui/src/components/layouts/AppLayout.tsx
+++ b/cyclops-ui/src/components/layouts/AppLayout.tsx
@@ -1,5 +1,5 @@
 import {Outlet} from "react-router-dom";
-import SideNav from "./sidebar";
+import SideNav from "./Sidebar";
 import {Suspense} from "react";
 import Sider from "antd/es/layout/Sider";
 import {Content, Header} from "antd/es/layout/layout";

--- a/cyclops-ui/src/components/layouts/Sidebar.tsx
+++ b/cyclops-ui/src/components/layouts/Sidebar.tsx
@@ -1,20 +1,34 @@
 import React from 'react';
-import { Menu } from 'antd';
+import {Menu, MenuProps} from 'antd';
 import {
     AppstoreAddOutlined,
     HddOutlined,
 } from '@ant-design/icons';
 import {useNavigate}  from 'react-router';
 import PathConstants from "../../routes/PathConstants";
+import { Link } from 'react-router-dom';
 
 const SideNav = () => {
-    const history = useNavigate();
-    const handleModulesClick = () => {
-        history('/modules');
-    }
-    const handleNodesClick = () => {
-        history('/nodes');
-    }
+    const navigate = useNavigate();
+    // const handleModulesClick = () => {
+    //     history('/modules');
+    // }
+    // const handleNodesClick = () => {
+    //     history('/nodes');
+    // }
+
+    const sidebarItems: MenuProps['items'] = [{
+        label: <Link to={PathConstants.MODULES}> Modules</Link>,
+        icon: <AppstoreAddOutlined/>,
+        key: 'modules'
+    }, {
+        label: <Link to={PathConstants.NODES}> Nodes</Link>,
+        icon: <HddOutlined/>,
+        key: 'nodes'
+    }];
+
+
+
     return (
         <div>
             <a href={PathConstants.HOME}>
@@ -24,16 +38,17 @@ const SideNav = () => {
                          src={require("./KIKLOPcic.png")} alt="Cyclops" />
                 </div>
             </a>
-            <Menu theme="dark" mode="inline" defaultSelectedKeys={['1']}>
-                <Menu.Item key="1" onClick={handleModulesClick}>
-                    <AppstoreAddOutlined />
-                    <span> Modules</span>
-                </Menu.Item>
-                <Menu.Item key="2" onClick={handleNodesClick}>
-                    <HddOutlined />
-                    <span> Nodes</span>
-                </Menu.Item>
-            </Menu>
+            <Menu theme="dark" mode="inline" defaultSelectedKeys={['modules']} items={sidebarItems}/>
+            {/*<Menu theme="dark" mode="inline" defaultSelectedKeys={['1']}>*/}
+            {/*    <Menu.Item key="1" onClick={handleModulesClick}>*/}
+            {/*        <AppstoreAddOutlined />*/}
+            {/*        <span> Modules</span>*/}
+            {/*    </Menu.Item>*/}
+            {/*    <Menu.Item key="2" onClick={handleNodesClick}>*/}
+            {/*        <HddOutlined />*/}
+            {/*        <span> Nodes</span>*/}
+            {/*    </Menu.Item>*/}
+            {/*</Menu>*/}
         </div>
     );
 }

--- a/cyclops-ui/src/components/layouts/Sidebar.tsx
+++ b/cyclops-ui/src/components/layouts/Sidebar.tsx
@@ -10,17 +10,16 @@ import { Link } from 'react-router-dom';
 
 
 const SideNav = () => {
-    const location = useLocation();
-    const locationKey = location.pathname.split('/', 2).join('/')
+    const location = useLocation().pathname.split('/')[1]
 
     const sidebarItems: MenuProps['items'] = [{
         label: <Link to={PathConstants.MODULES}> Modules</Link>,
         icon: <AppstoreAddOutlined/>,
-        key: '/modules'
+        key: 'modules'
     }, {
         label: <Link to={PathConstants.NODES}> Nodes</Link>,
         icon: <HddOutlined/>,
-        key: '/nodes'
+        key: 'nodes'
     }];
 
 
@@ -34,7 +33,7 @@ const SideNav = () => {
                          src={require("./KIKLOPcic.png")} alt="Cyclops" />
                 </div>
             </a>
-            <Menu theme="dark" mode="inline" selectedKeys={[locationKey]} items={sidebarItems}/>
+            <Menu theme="dark" mode="inline" selectedKeys={[location]} items={sidebarItems}/>
         </div>
     );
 }

--- a/cyclops-ui/src/components/layouts/Sidebar.tsx
+++ b/cyclops-ui/src/components/layouts/Sidebar.tsx
@@ -5,17 +5,10 @@ import {
     HddOutlined,
 } from '@ant-design/icons';
 import {useNavigate}  from 'react-router';
+import PathConstants from "../../routes/PathConstants";
+
 const SideNav = () => {
     const history = useNavigate();
-    const handleUserClick = () => {
-        history('/');
-    }
-    const handleVideosClick = () => {
-        history('/videos');
-    }
-    const handleFileClick = () => {
-        history('/configurations');
-    }
     const handleModulesClick = () => {
         history('/modules');
     }
@@ -24,10 +17,10 @@ const SideNav = () => {
     }
     return (
         <div>
-            <a href={'/'}>
-                <div style={{top: "0", height: "32px", width: "100%", margin: "1rem", display: "inline-flex", alignContent: "center"}}>
-                    <h2 style={{verticalAlign: "center", color: "white", textAlign: "center", textSizeAdjust: "120%"}}><b>Cyclops</b></h2>{'       '}
-                    <img  style={{height: "120%", objectFit: "contain", marginLeft: "6px"}}
+            <a href={PathConstants.HOME}>
+                <div style={{height: "32px", width: "70%", margin: "0.9rem 1rem 0.6rem 2rem", display: "inline-flex"}}>
+                    <h2 style={{color: "white", marginTop: "5px"}}><b>Cyclops</b></h2>
+                    <img  style={{height: "120%", marginLeft: "6px"}}
                          src={require("./KIKLOPcic.png")} alt="Cyclops" />
                 </div>
             </a>

--- a/cyclops-ui/src/components/layouts/Sidebar.tsx
+++ b/cyclops-ui/src/components/layouts/Sidebar.tsx
@@ -4,51 +4,37 @@ import {
     AppstoreAddOutlined,
     HddOutlined,
 } from '@ant-design/icons';
-import {useNavigate}  from 'react-router';
+import {useLocation} from 'react-router';
 import PathConstants from "../../routes/PathConstants";
 import { Link } from 'react-router-dom';
 
+
 const SideNav = () => {
-    const navigate = useNavigate();
-    // const handleModulesClick = () => {
-    //     history('/modules');
-    // }
-    // const handleNodesClick = () => {
-    //     history('/nodes');
-    // }
+    const location = useLocation();
+    const locationKey = location.pathname.split('/', 2).join('/')
 
     const sidebarItems: MenuProps['items'] = [{
         label: <Link to={PathConstants.MODULES}> Modules</Link>,
         icon: <AppstoreAddOutlined/>,
-        key: 'modules'
+        key: '/modules'
     }, {
         label: <Link to={PathConstants.NODES}> Nodes</Link>,
         icon: <HddOutlined/>,
-        key: 'nodes'
+        key: '/nodes'
     }];
 
 
 
     return (
         <div>
-            <a href={PathConstants.HOME}>
+            <a href={PathConstants.MODULES}>
                 <div style={{height: "32px", width: "70%", margin: "0.9rem 1rem 0.6rem 2rem", display: "inline-flex"}}>
                     <h2 style={{color: "white", marginTop: "5px"}}><b>Cyclops</b></h2>
                     <img  style={{height: "120%", marginLeft: "6px"}}
                          src={require("./KIKLOPcic.png")} alt="Cyclops" />
                 </div>
             </a>
-            <Menu theme="dark" mode="inline" defaultSelectedKeys={['modules']} items={sidebarItems}/>
-            {/*<Menu theme="dark" mode="inline" defaultSelectedKeys={['1']}>*/}
-            {/*    <Menu.Item key="1" onClick={handleModulesClick}>*/}
-            {/*        <AppstoreAddOutlined />*/}
-            {/*        <span> Modules</span>*/}
-            {/*    </Menu.Item>*/}
-            {/*    <Menu.Item key="2" onClick={handleNodesClick}>*/}
-            {/*        <HddOutlined />*/}
-            {/*        <span> Nodes</span>*/}
-            {/*    </Menu.Item>*/}
-            {/*</Menu>*/}
+            <Menu theme="dark" mode="inline" selectedKeys={[locationKey]} items={sidebarItems}/>
         </div>
     );
 }

--- a/cyclops-ui/src/components/pages/Page404.tsx
+++ b/cyclops-ui/src/components/pages/Page404.tsx
@@ -1,5 +1,5 @@
 import Sider from "antd/es/layout/Sider";
-import SideNav from "../layouts/sidebar";
+import SideNav from "../layouts/Sidebar";
 import {Layout} from "antd";
 import {Content, Header} from "antd/es/layout/layout";
 


### PR DESCRIPTION
## Changes:
- capitalized the name of the file
- removed some excess CSS styling for the Cyclops logo and repositioned it for a more centered appearance in the corner
- instead of `useNavigate`, we now use `useLocation` from which we can get the current URL (needed for the highlight of sidebar items)
- updated the `Menu` for easier management in the future
  - the `key` property correlates to the path of the rendered component
  
### Bugfixes with this PR:
- when going back/forward via browser arrows, the correct item is still highlighted