### PR TITLE
Suggest versions for a selected template

### DIFF
--- a/cyclops-ctrl/internal/models/templates.go
+++ b/cyclops-ctrl/internal/models/templates.go
@@ -14,6 +14,7 @@ type Template struct {
 	Edited   string       `json:"edited"`
 	Modules  []dto.Module `json:"modules"`
 	Version  string       `json:"version"`
+	Versions []string     `json:"versions"`
 
 	Files []*chart.File `json:"files"`
 


### PR DESCRIPTION
Return possible versions for a selected template, making usage of a template version easier.

Will help prevent wrong (unexistent) template versions.

Support fetching versions for different sources of templates
 - git - branches and tags
 - helm repo - semantic versions
 -  OCI - semantic versions