### PR TITLE
Support building release candidates in GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,44 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  build-UI:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push
-        run: |
-          TAG=${{ github.event.inputs.version }}
-
-          docker build cyclops-ui -t cyclopsui/cyclops-ui:$TAG
-          docker push cyclopsui/cyclops-ui:$TAG
-
-  build-controller:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build and push
-        run: |
-          TAG=${{ github.event.inputs.version }}
-
-          docker build cyclops-ctrl -t cyclopsui/cyclops-ctrl:$TAG
-          docker push cyclopsui/cyclops-ctrl:$TAG
-
-  update-install-manifest:
-    needs:
-      - build-UI
-      - build-controller
+  first:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -59,36 +22,87 @@ jobs:
       - name: update install manifest
         run: |
           echo ${{ steps.extract_branch.outputs.branch }}
-          
+
           exit 1
-          
-          TAG=${{ github.event.inputs.version }}
-          INSTALL_YAML=$GITHUB_WORKSPACE/install/cyclops-install.yaml
-
-          sed -i 's/cyclopsui\/cyclops-ctrl\:.*/cyclopsui\/cyclops-ctrl\:'$TAG'/' $INSTALL_YAML
-          sed -i 's/cyclopsui\/cyclops-ui\:.*/cyclopsui\/cyclops-ui\:'$TAG'/' $INSTALL_YAML
-
-          # update file
-          git fetch origin main
-          git checkout main
-          git config --global user.email "petar.cvitanovic@gmail.com"
-          git config --global user.name "petar-cvit"
-          git status
-          git add $INSTALL_YAML
-          git commit -m '⚙️ update cyclops to '$TAG
-          git push origin HEAD:main
-
-  release:
-    needs:
-      - update-install-manifest
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Create release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create ${{ github.event.inputs.version }} \
-            --repo="https://github.com/cyclops-ui/cyclops" \
-            --title="${{ github.event.inputs.version }}" \
-            --generate-notes
+#
+#  build-UI:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Login to DockerHub
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#      - name: Build and push
+#        run: |
+#          TAG=${{ github.event.inputs.version }}
+#
+#          docker build cyclops-ui -t cyclopsui/cyclops-ui:$TAG
+#          docker push cyclopsui/cyclops-ui:$TAG
+#
+#  build-controller:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Login to DockerHub
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#      - name: Build and push
+#        run: |
+#          TAG=${{ github.event.inputs.version }}
+#
+#          docker build cyclops-ctrl -t cyclopsui/cyclops-ctrl:$TAG
+#          docker push cyclopsui/cyclops-ctrl:$TAG
+#
+#  update-install-manifest:
+#    needs:
+#      - build-UI
+#      - build-controller
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Extract branch name
+#        shell: bash
+#        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+#        id: extract_branch
+#      - name: update install manifest
+#        run: |
+#          echo ${{ steps.extract_branch.outputs.branch }}
+#
+#          exit 1
+#
+#          TAG=${{ github.event.inputs.version }}
+#          INSTALL_YAML=$GITHUB_WORKSPACE/install/cyclops-install.yaml
+#
+#          sed -i 's/cyclopsui\/cyclops-ctrl\:.*/cyclopsui\/cyclops-ctrl\:'$TAG'/' $INSTALL_YAML
+#          sed -i 's/cyclopsui\/cyclops-ui\:.*/cyclopsui\/cyclops-ui\:'$TAG'/' $INSTALL_YAML
+#
+#          # update file
+#          git fetch origin main
+#          git checkout main
+#          git config --global user.email "petar.cvitanovic@gmail.com"
+#          git config --global user.name "petar-cvit"
+#          git status
+#          git add $INSTALL_YAML
+#          git commit -m '⚙️ update cyclops to '$TAG
+#          git push origin HEAD:main
+#
+#  release:
+#    needs:
+#      - update-install-manifest
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Create release
+#        env:
+#          GH_TOKEN: ${{ github.token }}
+#        run: |
+#          gh release create ${{ github.event.inputs.version }} \
+#            --repo="https://github.com/cyclops-ui/cyclops" \
+#            --title="${{ github.event.inputs.version }}" \
+#            --generate-notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ github.event.inputs.version }} \
-            --repo="https://github.com/cyclops-ui/cyclops" \
-            --title="${{ github.event.inputs.version }}" \
-            --generate-notes
+          if [ "$var" = "something" ]; then
+            gh release create ${{ github.event.inputs.version }} \
+              --repo="https://github.com/cyclops-ui/cyclops" \
+              --title="${{ github.event.inputs.version }}" \
+              --generate-notes
+          else
+            gh release create ${{ github.event.inputs.version }} \
+              --repo="https://github.com/cyclops-ui/cyclops" \
+              --title="${{ github.event.inputs.version }}" \
+              --generate-notes \
+              --prerelease
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
       - name: update install manifest
         run: |
+          echo ${{ steps.extract_branch.outputs.branch }}
+          
+          exit 1
+          
           TAG=${{ github.event.inputs.version }}
           INSTALL_YAML=$GITHUB_WORKSPACE/install/cyclops-install.yaml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,44 @@ permissions:
   contents: write
 
 jobs:
-  first:
+  build-UI:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        run: |
+          TAG=${{ github.event.inputs.version }}
+
+          docker build cyclops-ui -t cyclopsui/cyclops-ui:$TAG
+          docker push cyclopsui/cyclops-ui:$TAG
+
+  build-controller:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        run: |
+          TAG=${{ github.event.inputs.version }}
+
+          docker build cyclops-ctrl -t cyclopsui/cyclops-ctrl:$TAG
+          docker push cyclopsui/cyclops-ctrl:$TAG
+
+  update-install-manifest:
+    needs:
+      - build-UI
+      - build-controller
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -21,88 +58,33 @@ jobs:
         id: extract_branch
       - name: update install manifest
         run: |
-          echo ${{ steps.extract_branch.outputs.branch }}
+          TAG=${{ github.event.inputs.version }}
+          INSTALL_YAML=$GITHUB_WORKSPACE/install/cyclops-install.yaml
 
-          exit 1
-#
-#  build-UI:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Login to DockerHub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#
-#      - name: Build and push
-#        run: |
-#          TAG=${{ github.event.inputs.version }}
-#
-#          docker build cyclops-ui -t cyclopsui/cyclops-ui:$TAG
-#          docker push cyclopsui/cyclops-ui:$TAG
-#
-#  build-controller:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Login to DockerHub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#
-#      - name: Build and push
-#        run: |
-#          TAG=${{ github.event.inputs.version }}
-#
-#          docker build cyclops-ctrl -t cyclopsui/cyclops-ctrl:$TAG
-#          docker push cyclopsui/cyclops-ctrl:$TAG
-#
-#  update-install-manifest:
-#    needs:
-#      - build-UI
-#      - build-controller
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Extract branch name
-#        shell: bash
-#        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-#        id: extract_branch
-#      - name: update install manifest
-#        run: |
-#          echo ${{ steps.extract_branch.outputs.branch }}
-#
-#          exit 1
-#
-#          TAG=${{ github.event.inputs.version }}
-#          INSTALL_YAML=$GITHUB_WORKSPACE/install/cyclops-install.yaml
-#
-#          sed -i 's/cyclopsui\/cyclops-ctrl\:.*/cyclopsui\/cyclops-ctrl\:'$TAG'/' $INSTALL_YAML
-#          sed -i 's/cyclopsui\/cyclops-ui\:.*/cyclopsui\/cyclops-ui\:'$TAG'/' $INSTALL_YAML
-#
-#          # update file
-#          git fetch origin main
-#          git checkout main
-#          git config --global user.email "petar.cvitanovic@gmail.com"
-#          git config --global user.name "petar-cvit"
-#          git status
-#          git add $INSTALL_YAML
-#          git commit -m '⚙️ update cyclops to '$TAG
-#          git push origin HEAD:main
-#
-#  release:
-#    needs:
-#      - update-install-manifest
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Create release
-#        env:
-#          GH_TOKEN: ${{ github.token }}
-#        run: |
-#          gh release create ${{ github.event.inputs.version }} \
-#            --repo="https://github.com/cyclops-ui/cyclops" \
-#            --title="${{ github.event.inputs.version }}" \
-#            --generate-notes
+          sed -i 's/cyclopsui\/cyclops-ctrl\:.*/cyclopsui\/cyclops-ctrl\:'$TAG'/' $INSTALL_YAML
+          sed -i 's/cyclopsui\/cyclops-ui\:.*/cyclopsui\/cyclops-ui\:'$TAG'/' $INSTALL_YAML
+
+          # update file
+          git fetch origin ${{ steps.extract_branch.outputs.branch }}
+          git checkout ${{ steps.extract_branch.outputs.branch }}
+          git config --global user.email "petar.cvitanovic@gmail.com"
+          git config --global user.name "petar-cvit"
+          git status
+          git add $INSTALL_YAML
+          git commit -m '⚙️ update cyclops to '$TAG
+          git push origin HEAD:${{ steps.extract_branch.outputs.branch }}
+
+  release:
+    needs:
+      - update-install-manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create ${{ github.event.inputs.version }} \
+            --repo="https://github.com/cyclops-ui/cyclops" \
+            --title="${{ github.event.inputs.version }}" \
+            --generate-notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "$var" = "something" ]; then
+          if [ "${{ steps.extract_branch.outputs.branch }}" = "main" ]; then
             gh release create ${{ github.event.inputs.version }} \
               --repo="https://github.com/cyclops-ui/cyclops" \
               --title="${{ github.event.inputs.version }}" \
@@ -94,5 +98,6 @@ jobs:
               --repo="https://github.com/cyclops-ui/cyclops" \
               --title="${{ github.event.inputs.version }}" \
               --generate-notes \
+              --target ${{ steps.extract_branch.outputs.branch }}\
               --prerelease
           fi

--- a/install/cyclops-install.yaml
+++ b/install/cyclops-install.yaml
@@ -249,7 +249,7 @@ spec:
     spec:
       containers:
         - name: cyclops-ui
-          image: cyclopsui/cyclops-ui:v0.0.1-alpha.13-rc
+          image: cyclopsui/cyclops-ui:v0.0.1-alpha.13-rc-2
           ports:
             - containerPort: 80
           env:
@@ -295,7 +295,7 @@ spec:
       serviceAccountName: cyclops-ctrl
       containers:
         - name: cyclops-ctrl
-          image: cyclopsui/cyclops-ctrl:v0.0.1-alpha.13-rc
+          image: cyclopsui/cyclops-ctrl:v0.0.1-alpha.13-rc-2
           ports:
             - containerPort: 8080
           env:

--- a/install/cyclops-install.yaml
+++ b/install/cyclops-install.yaml
@@ -249,7 +249,7 @@ spec:
     spec:
       containers:
         - name: cyclops-ui
-          image: cyclopsui/cyclops-ui:v0.0.1-alpha.13-rc-3
+          image: cyclopsui/cyclops-ui:v0.0.1-alpha.13-rc-4
           ports:
             - containerPort: 80
           env:
@@ -295,7 +295,7 @@ spec:
       serviceAccountName: cyclops-ctrl
       containers:
         - name: cyclops-ctrl
-          image: cyclopsui/cyclops-ctrl:v0.0.1-alpha.13-rc-3
+          image: cyclopsui/cyclops-ctrl:v0.0.1-alpha.13-rc-4
           ports:
             - containerPort: 8080
           env:

--- a/install/cyclops-install.yaml
+++ b/install/cyclops-install.yaml
@@ -249,7 +249,7 @@ spec:
     spec:
       containers:
         - name: cyclops-ui
-          image: cyclopsui/cyclops-ui:v0.0.1-alpha.13-rc-2
+          image: cyclopsui/cyclops-ui:v0.0.1-alpha.13-rc-3
           ports:
             - containerPort: 80
           env:
@@ -295,7 +295,7 @@ spec:
       serviceAccountName: cyclops-ctrl
       containers:
         - name: cyclops-ctrl
-          image: cyclopsui/cyclops-ctrl:v0.0.1-alpha.13-rc-2
+          image: cyclopsui/cyclops-ctrl:v0.0.1-alpha.13-rc-3
           ports:
             - containerPort: 8080
           env:

--- a/install/cyclops-install.yaml
+++ b/install/cyclops-install.yaml
@@ -249,7 +249,7 @@ spec:
     spec:
       containers:
         - name: cyclops-ui
-          image: cyclopsui/cyclops-ui:v0.0.1-alpha.12
+          image: cyclopsui/cyclops-ui:v0.0.1-alpha.13-rc
           ports:
             - containerPort: 80
           env:
@@ -295,7 +295,7 @@ spec:
       serviceAccountName: cyclops-ctrl
       containers:
         - name: cyclops-ctrl
-          image: cyclopsui/cyclops-ctrl:v0.0.1-alpha.12
+          image: cyclopsui/cyclops-ctrl:v0.0.1-alpha.13-rc
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
Using this GH action, we will be able to build release candidates from feature branches without updating install manifest on main branch