### PR TITLE
Updated link to CRDs manifest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,8 @@ You can install minikube and run it using `minikube start`. It will set up a Kub
 > You can install it using the command below:
 >
 > ```zsh
-> kubectl apply -f https://raw.githubusercontent.com/cyclops-ui/cyclops/main/install/chart/crds/cyclops-module.yaml
+> kubectl apply -f https://raw.githubusercontent.com/cyclops-ui/cyclops/main/install/chart/crds/cyclops-module.yaml \
+>   -f https://raw.githubusercontent.com/cyclops-ui/cyclops/main/install/chart/crds/template-auth-rule.yaml
 > ```
 
 ### **Controller** `/cyclops-ctrl`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ You can install minikube and run it using `minikube start`. It will set up a Kub
 > You can install it using the command below:
 >
 > ```zsh
-> kubectl apply -f https://raw.githubusercontent.com/cyclops-ui/cyclops/main/install/CRDs/cyclops-module.yaml
+> kubectl apply -f https://raw.githubusercontent.com/cyclops-ui/cyclops/main/install/chart/crds/cyclops-module.yaml
 > ```
 
 ### **Controller** `/cyclops-ctrl`


### PR DESCRIPTION
The CRDs manifest seems to have moved into the chart directory, but the link for installing CRDs wasn't updated.