### PR TITLE
Fixes issue #155 Wrong filenames in template dependencies

### DIFF
--- a/cyclops-ctrl/internal/template/helm.go
+++ b/cyclops-ctrl/internal/template/helm.go
@@ -189,7 +189,7 @@ func (r Repo) mapHelmChart(chartName string, files map[string][]byte) (*models.T
 		}
 
 		chartFiles = append(chartFiles, &helmchart.File{
-			Name: path.Join(name[1:]),
+			Name: name,
 			Data: content,
 		})
 


### PR DESCRIPTION
### Fixes [Wrong filenames in template  dependencies](https://github.com/cyclops-ui/cyclops/issues/155).

`name` is a string containing the filename (including the path).
I don't know if the path is supposed to be included. It looks to me like the original intent was to write:
```
Name: path.Join(parts[1:]...)
```

### Example

For a file `demo/values.yaml`, before the `chart.Name` would be `emo/values.yaml`
Using `name`, it will be `demo/values.yaml`.
Using `path.Join(parts[1:]...)` it will be `values.yaml`.