### PR TITLE
🕒 fix fetching configmap data

### DIFF
--- a/cyclops-ui/src/components/k8s-resources/ConfigMap.tsx
+++ b/cyclops-ui/src/components/k8s-resources/ConfigMap.tsx
@@ -46,7 +46,7 @@ const ConfigMap = ({ name, namespace }: Props) => {
 
   useEffect(() => {
     fetchConfigMap();
-    const interval = setInterval(() => fetchConfigMap());
+    const interval = setInterval(() => fetchConfigMap(), 15000);
     return () => {
       clearInterval(interval);
     };


### PR DESCRIPTION
There was no defined interval timeout when fetching configmap data