### PR TITLE
fix :area/helm charts: Add Notes.txt to .helmignore

### DIFF
--- a/install/chart/.helmignore
+++ b/install/chart/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# Ignore Notes.txt file
+Notes.txt

--- a/install/chart/Chart.yaml
+++ b/install/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cyclops-chart
 description: Cyclops Helm chart
 type: application
-version: "0.3.0"
+version: "0.3.1"
 appVersion: "v0.3.0"
 home: https://cyclops-ui.com/
 keywords:


### PR DESCRIPTION
Fixes #203 


## Installing helm chart before adding `Notes.txt` to `.helmignore`
```
$ helm install my-cyclops cyclops-chart-0.3.0.tgz
Error: INSTALLATION FAILED: YAML parse error on cyclops-chart/templates/cyclops-ctrl/Notest.txt: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type releaseutil.SimpleHead
```

## Installing helm chart after adding `Notes.txt` to `.helmignore`
```
helm install my-cyclops cyclops-chart-0.3.1.tgz
NAME: my-cyclops
LAST DEPLOYED: Sun Apr 21 17:50:49 2024
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None

$ kubectl get all 
-n cyclops
NAME                               READY   STATUS    RESTARTS   AGE
pod/cyclops-ctrl-f7598c8bb-fvppt   1/1     Running   0          14s
pod/cyclops-ui-55d897cb5-txp4j     1/1     Running   0          14s

NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
service/cyclops-ctrl   ClusterIP      10.105.12.177   <none>        8080/TCP         14s
service/cyclops-ui     LoadBalancer   10.105.155.75   <pending>     3000:31384/TCP   14s

NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/cyclops-ctrl   1/1     1            1           14s
deployment.apps/cyclops-ui     1/1     1            1           14s

NAME                                     DESIRED   CURRENT   READY   AGE
replicaset.apps/cyclops-ctrl-f7598c8bb   1         1         1       14s
replicaset.apps/cyclops-ui-55d897cb5     1         1         1       14s

$ kubectl port-forward svc/cyclops-ui 3000:3000 -n cyclops
Forwarding from 127.0.0.1:3000 -> 80
Forwarding from [::1]:3000 -> 80
Handling connection for 3000
Handling connection for 3000
```

![image](https://github.com/cyclops-ui/cyclops/assets/99421476/448e50b0-0444-4f18-be8f-3edbef489662)
