### PR TITLE
fix: area/Helm charts: Add support for Notes.txt in Helm Chart

### DIFF
--- a/cyclops-ctrl/internal/template/helm.go
+++ b/cyclops-ctrl/internal/template/helm.go
@@ -173,7 +173,7 @@ func (r Repo) mapHelmChart(chartName string, files map[string][]byte) (*models.T
 			continue
 		}
 
-		if len(parts) > 2 && parts[1] == "templates" && parts[2] != "Notes.txt" {
+		if len(parts) > 2 && parts[1] == "templates" && (parts[2] != "Notes.txt" && parts[2] != "NOTES.txt") {
 			manifestParts = append(manifestParts, string(content))
 			continue
 		}

--- a/cyclops-ctrl/internal/template/helm.go
+++ b/cyclops-ctrl/internal/template/helm.go
@@ -173,7 +173,7 @@ func (r Repo) mapHelmChart(chartName string, files map[string][]byte) (*models.T
 			continue
 		}
 
-		if len(parts) > 2 && parts[1] == "templates" {
+		if len(parts) > 2 && parts[1] == "templates" && parts[2] != "Notes.txt" {
 			manifestParts = append(manifestParts, string(content))
 			continue
 		}


### PR DESCRIPTION
Fixes #203 

## Successfully deployed the template which broke Cyclops before:

![image](https://github.com/cyclops-ui/cyclops/assets/99421476/4bb59f4a-5c4a-43da-81cd-3ea2ba14620a)

![image](https://github.com/cyclops-ui/cyclops/assets/99421476/4226709a-e1cc-4e36-b586-cbf9d1f32496)


![image](https://github.com/cyclops-ui/cyclops/assets/99421476/12917db3-2314-4809-a447-8447f2ab4f1b)
