### PR TITLE
Impl(backend): add pvc data fetch api functionality

### DIFF
--- a/cyclops-ctrl/internal/cluster/k8sclient/client.go
+++ b/cyclops-ctrl/internal/cluster/k8sclient/client.go
@@ -567,6 +567,11 @@ func (k *KubernetesClient) mapPersistentVolumeClaims(group, version, kind, name,
 		return nil, err
 	}
 
+	storage = 0
+	if persistentvolumeclaim.Spec.Resources != nil && persistentvolumeclaim.Spec.Resources.Requests != nil {
+		storage = persistentvolumeclaim.Spec.Resources.Requests.Storage
+	}
+
 	return &dto.PersistentVolumeClaim{
 		Group:     	 group,
 		Version:   	 version,
@@ -574,7 +579,7 @@ func (k *KubernetesClient) mapPersistentVolumeClaims(group, version, kind, name,
 		Name:      	 name,
 		Namespace: 	 namespace,
 		AccessModes: persistentvolumeclaim.Spec.AccessModes,
-		Size: 		 persistentvolumeclaim.Spec.Resources.Requests.Storage,
+		Size: 		 storage,
 	}, nil
 }
 

--- a/cyclops-ctrl/internal/cluster/k8sclient/client.go
+++ b/cyclops-ctrl/internal/cluster/k8sclient/client.go
@@ -573,8 +573,8 @@ func (k *KubernetesClient) mapPersistentVolumeClaims(group, version, kind, name,
 		Kind:      	 kind,
 		Name:      	 name,
 		Namespace: 	 namespace,
-		AccessModes: persistentvolumeclaim.spec.accessModes,
-		Size: 		 persistentvolumeclaim.spec.resources.requests.storage,
+		AccessModes: persistentvolumeclaim.Spec.AccessModes,
+		Size: 		 persistentvolumeclaim.Spec.Resources.Requests.Storage,
 	}, nil
 }
 

--- a/cyclops-ctrl/internal/cluster/k8sclient/client.go
+++ b/cyclops-ctrl/internal/cluster/k8sclient/client.go
@@ -567,9 +567,9 @@ func (k *KubernetesClient) mapPersistentVolumeClaims(group, version, kind, name,
 		return nil, err
 	}
 
-	storage = 0
-	if persistentvolumeclaim.Spec.Resources != nil && persistentvolumeclaim.Spec.Resources.Requests != nil {
-		storage = persistentvolumeclaim.Spec.Resources.Requests.Storage
+	storage := ""
+	if persistentvolumeclaim.Spec.Resources.Requests != nil && persistentvolumeclaim.Spec.Resources.Requests.Storage() != nil {
+		storage = persistentvolumeclaim.Spec.Resources.Requests.Storage().String()
 	}
 
 	return &dto.PersistentVolumeClaim{

--- a/cyclops-ctrl/internal/models/dto/k8s.go
+++ b/cyclops-ctrl/internal/models/dto/k8s.go
@@ -248,6 +248,48 @@ func (s *StatefulSet) SetDeleted(deleted bool) {
 	s.Deleted = deleted
 }
 
+type PersistentVolumeClaim struct {
+	Group       string 							`json:"group"`
+	Version     string 							`json:"version"`
+	Kind        string 							`json:"kind"`
+	Name        string 							`json:"name"`
+	Namespace   string 							`json:"namespace"`
+	AccessModes []v1.PersistentVolumeAccessMode `json:"accessmodes"`
+	Size        string							`json:"size"`
+}
+
+func (p *PersistentVolumeClaim) GetGroupVersionKind() string {
+	return p.Group + "/" + p.Version + ", Kind=" + p.Kind
+}
+
+func (p *PersistentVolumeClaim) GetGroup() string {
+	return p.Group
+}
+
+func (p *PersistentVolumeClaim) GetVersion() string {
+	return p.Version
+}
+
+func (p *PersistentVolumeClaim) GetKind() string {
+	return p.Kind
+}
+
+func (p *PersistentVolumeClaim) GetName() string {
+	return p.Name
+}
+
+func (p *PersistentVolumeClaim) GetNamespace() string {
+	return p.Namespace
+}
+
+func (p *PersistentVolumeClaim) GetDeleted() bool {
+	return p.Deleted
+}
+
+func (p *PersistentVolumeClaim) SetDeleted(deleted bool) {
+	p.Deleted = deleted
+}
+
 type Other struct {
 	Group     string `json:"group"`
 	Version   string `json:"version"`

--- a/cyclops-ctrl/internal/models/dto/k8s.go
+++ b/cyclops-ctrl/internal/models/dto/k8s.go
@@ -256,6 +256,7 @@ type PersistentVolumeClaim struct {
 	Namespace   string 							`json:"namespace"`
 	AccessModes []v1.PersistentVolumeAccessMode `json:"accessmodes"`
 	Size        string							`json:"size"`
+	Deleted   	bool   							`json:"deleted"`
 }
 
 func (p *PersistentVolumeClaim) GetGroupVersionKind() string {


### PR DESCRIPTION
Implements #258
Closes #258

## Description 
This PR adds support for fetching PersistentVolumeClaims data on /resource endpoint in `cyclops-ctrl`.