### PR TITLE
ft(cyctl): Delete modules functionality

### DIFF
--- a/cyctl/cmd/delete.go
+++ b/cyctl/cmd/delete.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/cyclops-ui/cycops-cyctl/internal/delete"
+	"github.com/cyclops-ui/cycops-cyctl/internal/kubeconfig"
+	"github.com/spf13/cobra"
+)
+
+var deleteCMD = &cobra.Command{
+	Use:   "delete",
+	Short: "This is the delete command",
+	Long:  "This is the delete command",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		deleteCommand, resourceName := args[0], args[1]
+		switch deleteCommand {
+		case "modules", "module":
+			delete.DeleteModules(kubeconfig.Moduleset, resourceName)
+		default:
+			fmt.Println("Give the correct resource name")
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(deleteCMD)
+}

--- a/cyctl/internal/delete/modules.go
+++ b/cyctl/internal/delete/modules.go
@@ -1,0 +1,17 @@
+package delete
+
+import (
+	"fmt"
+
+	"github.com/cyclops-ui/cyclops/cyclops-ctrl/api/v1alpha1/client"
+)
+
+// DeleteModules deletes a specified module from the Cyclops API.
+func DeleteModules(clientset *client.CyclopsV1Alpha1Client, moduleName string) {
+	err := clientset.Modules("cyclops").Delete(moduleName)
+	if err != nil {
+		fmt.Printf("Error deleting the module: %v\n", err)
+		return
+	}
+	fmt.Printf("module '%v' deleted", moduleName)
+}

--- a/cyctl/internal/delete/modules.go
+++ b/cyctl/internal/delete/modules.go
@@ -8,10 +8,14 @@ import (
 
 // DeleteModules deletes a specified module from the Cyclops API.
 func DeleteModules(clientset *client.CyclopsV1Alpha1Client, moduleName string) {
-	err := clientset.Modules("cyclops").Delete(moduleName)
-	if err != nil {
-		fmt.Printf("Error deleting the module: %v\n", err)
-		return
+	if len(moduleName) > 0 {
+		err := clientset.Modules("cyclops").Delete(moduleName)
+		if err != nil {
+			fmt.Printf("Error deleting the module: %v\n", err)
+			return
+		}
+		fmt.Printf("module '%v' deleted", moduleName)
+	} else {
+		fmt.Println("Error: module name cannot be empty")
 	}
-	fmt.Printf("module '%v' deleted", moduleName)
 }

--- a/cyctl/internal/get/modules.go
+++ b/cyctl/internal/get/modules.go
@@ -16,16 +16,18 @@ func ListModules(clientset *client.CyclopsV1Alpha1Client) {
 		return
 	}
 
-	longestName := 0
+	longestName := 20 // minimum column width
 	for _, module := range modules {
 		if len(module.Name) > longestName {
 			longestName = len(module.Name)
 		}
 	}
 
-	fmt.Println("NAME" + strings.Repeat(" ", longestName-4) + " AGE")
+	headerSpacing := max(0, longestName-4)
+	fmt.Println("NAME" + strings.Repeat(" ", headerSpacing) + " AGE")
 	for _, module := range modules {
 		age := time.Since(module.CreationTimestamp.Time).Round(time.Second)
-		fmt.Printf("%s"+strings.Repeat(" ", longestName-len(module.Name))+" %s\n", module.Name, age.String())
+		nameSpacing := max(0, longestName-len(module.Name))
+		fmt.Printf("%s"+strings.Repeat(" ", nameSpacing)+" %s\n", module.Name, age.String())
 	}
 }


### PR DESCRIPTION
closes #239

## 📑 Description
- Implements module deletion functionality via `cyctl` command.
```bash
cyctl delete module <MODULE_NAME>
```
- Added minimum spacing when no modules are present.

## ✅ Checks
- [ ] I have updated the documentation as required
- [ ] I have performed a self-review of my code

## ℹ Additional context

Suggestion:
- I believe, we need to added additionally functionality of deleting multiple modules 
```bash
cyctl delete module MODULE_1 MODULE_2 MODULE_3 ...
```