### PR TITLE
ft(cyclops-ctrl): Added support for fetching Secret resources

### DIFF
--- a/cyclops-ctrl/internal/cluster/k8sclient/client.go
+++ b/cyclops-ctrl/internal/cluster/k8sclient/client.go
@@ -615,13 +615,18 @@ func (k *KubernetesClient) mapSecret(group, version, kind, name, namespace strin
 		return nil, err
 	}
 
+	dataKeys := make([]string, 0, len(secret.Data))
+	for key := range secret.Data {
+		dataKeys = append(dataKeys, key)
+	}
+
 	return &dto.Secret{
 		Group:     group,
 		Version:   version,
 		Kind:      kind,
 		Name:      name,
 		Namespace: namespace,
-		Data:      secret.Data,
+		DataKeys:  dataKeys,
 		Type:      string(secret.Type),
 	}, nil
 }

--- a/cyclops-ctrl/internal/models/dto/k8s.go
+++ b/cyclops-ctrl/internal/models/dto/k8s.go
@@ -249,14 +249,14 @@ func (s *StatefulSet) SetDeleted(deleted bool) {
 }
 
 type PersistentVolumeClaim struct {
-	Group       string 							`json:"group"`
-	Version     string 							`json:"version"`
-	Kind        string 							`json:"kind"`
-	Name        string 							`json:"name"`
-	Namespace   string 							`json:"namespace"`
+	Group       string                          `json:"group"`
+	Version     string                          `json:"version"`
+	Kind        string                          `json:"kind"`
+	Name        string                          `json:"name"`
+	Namespace   string                          `json:"namespace"`
 	AccessModes []v1.PersistentVolumeAccessMode `json:"accessmodes"`
-	Size        string							`json:"size"`
-	Deleted   	bool   							`json:"deleted"`
+	Size        string                          `json:"size"`
+	Deleted     bool                            `json:"deleted"`
 }
 
 func (p *PersistentVolumeClaim) GetGroupVersionKind() string {
@@ -289,6 +289,57 @@ func (p *PersistentVolumeClaim) GetDeleted() bool {
 
 func (p *PersistentVolumeClaim) SetDeleted(deleted bool) {
 	p.Deleted = deleted
+}
+
+type Secret struct {
+	Group     string            `json:"group"`
+	Version   string            `json:"version"`
+	Kind      string            `json:"kind"`
+	Name      string            `json:"name"`
+	Namespace string            `json:"namespace"`
+	Type      string            `json:"type"`
+	Data      map[string][]byte `json:"data"`
+	Deleted   bool              `json:"deleted"`
+}
+
+func (s *Secret) GetGroupVersionKind() string {
+	return s.Group + "/" + s.Version + ", Kind=" + s.Kind
+}
+
+func (s *Secret) GetGroup() string {
+	return s.Group
+}
+
+func (s *Secret) GetVersion() string {
+	return s.Version
+}
+
+func (s *Secret) GetKind() string {
+	return s.Kind
+}
+
+func (s *Secret) GetName() string {
+	return s.Name
+}
+
+func (s *Secret) GetNamespace() string {
+	return s.Namespace
+}
+
+func (s *Secret) GetType() string {
+	return s.Type
+}
+
+func (s *Secret) GetData() map[string][]byte {
+	return s.Data
+}
+
+func (s *Secret) GetDeleted() bool {
+	return s.Deleted
+}
+
+func (s *Secret) SetDeleted(deleted bool) {
+	s.Deleted = deleted
 }
 
 type Other struct {

--- a/cyclops-ctrl/internal/models/dto/k8s.go
+++ b/cyclops-ctrl/internal/models/dto/k8s.go
@@ -292,14 +292,14 @@ func (p *PersistentVolumeClaim) SetDeleted(deleted bool) {
 }
 
 type Secret struct {
-	Group     string            `json:"group"`
-	Version   string            `json:"version"`
-	Kind      string            `json:"kind"`
-	Name      string            `json:"name"`
-	Namespace string            `json:"namespace"`
-	Type      string            `json:"type"`
-	Data      map[string][]byte `json:"data"`
-	Deleted   bool              `json:"deleted"`
+	Group     string   `json:"group"`
+	Version   string   `json:"version"`
+	Kind      string   `json:"kind"`
+	Name      string   `json:"name"`
+	Namespace string   `json:"namespace"`
+	Type      string   `json:"type"`
+	DataKeys  []string `json:"dataKeys"`
+	Deleted   bool     `json:"deleted"`
 }
 
 func (s *Secret) GetGroupVersionKind() string {
@@ -330,8 +330,8 @@ func (s *Secret) GetType() string {
 	return s.Type
 }
 
-func (s *Secret) GetData() map[string][]byte {
-	return s.Data
+func (s *Secret) GetDataKeys() []string {
+	return s.DataKeys
 }
 
 func (s *Secret) GetDeleted() bool {


### PR DESCRIPTION
This resolves
closes #271

### Endpoint:
```
GET /resources?group=&version=v1&kind=Secret&name=<secret-name>&namespace=<namespace>
```

Implementation result
```
GET { HOST }/resources?group=&version=v1&kind=Secret&name=justsecret-2&namespace=cyclops
```
Output Response:
```json
{
    "group": "",
    "version": "v1",
    "kind": "Secret",
    "name": "justsecret-2",
    "namespace": "cyclops",
    "type": "Opaque",
    "data": {
        "KEY": "VkFMVUU="
    },
    "deleted": false
}
```

## 📑 Description


## ✅ Checks
- [ ] I have updated the documentation as required
- [x] I have performed a self-review of my code


