### PR TITLE
`cyctl` create command for template and templateauthrule

### DIFF
--- a/cyctl/cmd/create.go
+++ b/cyctl/cmd/create.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/cyclops-ui/cycops-cyctl/internal/create"
+	"github.com/spf13/cobra"
+)
+
+var (
+	createExample = `
+	# Create one or more modules
+	cyctl create modules NAME
+ 
+	# Create one or more templates
+	cyctl create template NAME --repo='github.com/repo/a' --path='/path/to/charts' --version='main'
+ 
+	# Create one or more templateauthrules.
+	cyctl create templateauthrule NAME --repo='https://github.com/cyclops-ui/templates' --username='name:john' --password='name:random'`
+)
+
+var createCMD = &cobra.Command{
+	Use:     "create",
+	Short:   "Create custom resources like modules, templates, and templateauthrules",
+	Long:    "Create custom resources like modules, templates, and templateauthrules",
+	Example: createExample,
+	Args:    cobra.MinimumNArgs(1),
+}
+
+func init() {
+	createCMD.AddCommand(create.CreateTemplate)
+	createCMD.AddCommand(create.CreateTemplateAuthRule)
+
+	RootCmd.AddCommand(createCMD)
+}

--- a/cyctl/go.mod
+++ b/cyctl/go.mod
@@ -7,6 +7,7 @@ toolchain go1.22.2
 require (
 	github.com/cyclops-ui/cyclops/cyclops-ctrl v0.0.0-20240421163218-f48a78b7c0e7
 	github.com/spf13/cobra v1.8.0
+	k8s.io/api v0.30.0
 	k8s.io/apimachinery v0.30.0
 	k8s.io/client-go v0.30.0
 	sigs.k8s.io/yaml v1.3.0
@@ -34,7 +35,6 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/api v0.30.0 // indirect
 	k8s.io/apiextensions-apiserver v0.29.0 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect

--- a/cyctl/internal/create/base.go
+++ b/cyctl/internal/create/base.go
@@ -1,0 +1,9 @@
+package create
+
+var (
+	// Repository URL
+	repo string
+
+	// Namespace where resource will be created
+	namespace string
+)

--- a/cyctl/internal/create/template_auth_rules.go
+++ b/cyctl/internal/create/template_auth_rules.go
@@ -46,6 +46,11 @@ func createTemplateAuthRule(clientset *client.CyclopsV1Alpha1Client, templateAut
 		passwordName = passwordSlice[0]
 	}
 
+	if usernameName == "" || passwordName == "" {
+		fmt.Printf("Invalid format for username or password. Both name and key are required.\n")
+		return
+	}
+
 	var localObjectNameRef, localObjectPasswordRef v1Spec.LocalObjectReference
 	if usernameName != "" {
 		localObjectNameRef = v1Spec.LocalObjectReference{

--- a/cyctl/internal/create/template_auth_rules.go
+++ b/cyctl/internal/create/template_auth_rules.go
@@ -27,8 +27,8 @@ var (
 )
 
 func validateSecretKeySelector(username, password string) (string, string, string, string, error) {
-	usernameName, usernameKey := _splitNameKey(username)
-	passwordName, passwordKey := _splitNameKey(password)
+	usernameName, usernameKey := splitNameKey(username)
+	passwordName, passwordKey := splitNameKey(password)
 
 	// Ensure both name and key are present
 	if usernameName == "" || usernameKey == "" || passwordName == "" || passwordKey == "" {
@@ -38,7 +38,7 @@ func validateSecretKeySelector(username, password string) (string, string, strin
 	return usernameName, usernameKey, passwordName, passwordKey, nil
 }
 
-func _splitNameKey(input string) (string, string) {
+func splitNameKey(input string) (string, string) {
 	parts := strings.SplitN(input, ":", 2)
 	if len(parts) < 2 {
 		return "", ""

--- a/cyctl/internal/create/template_auth_rules.go
+++ b/cyctl/internal/create/template_auth_rules.go
@@ -26,28 +26,31 @@ var (
 	password string
 )
 
+func validateSecretKeySelector(username, password string) (string, string, string, string, error) {
+	usernameName, usernameKey := _splitNameKey(username)
+	passwordName, passwordKey := _splitNameKey(password)
+
+	// Ensure both name and key are present
+	if usernameName == "" || usernameKey == "" || passwordName == "" || passwordKey == "" {
+		return "", "", "", "", fmt.Errorf("invalid format for username or password. Expected 'name:key'")
+	}
+
+	return usernameName, usernameKey, passwordName, passwordKey, nil
+}
+
+func _splitNameKey(input string) (string, string) {
+	parts := strings.SplitN(input, ":", 2)
+	if len(parts) < 2 {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}
+
 // createTemplateAuthRule allows you to create create TemplateAuthRule Custom Resource.
 func createTemplateAuthRule(clientset *client.CyclopsV1Alpha1Client, templateAuthRuleName string) {
-	usernameSlice := strings.Split(username, ":")
-	passwordSlice := strings.Split(password, ":")
-
-	// Ensure key is present for both username and password
-	if len(usernameSlice) < 2 || usernameSlice[1] == "" || len(passwordSlice) < 2 || passwordSlice[1] == "" {
-		fmt.Printf("Invalid format for username or password. Expected 'name:key'.\n")
-		return
-	}
-
-	usernameKey, passwordKey := usernameSlice[1], passwordSlice[1]
-	var usernameName, passwordName string
-	if len(usernameSlice) > 1 {
-		usernameName = usernameSlice[0]
-	}
-	if len(passwordSlice) > 1 {
-		passwordName = passwordSlice[0]
-	}
-
-	if usernameName == "" || passwordName == "" {
-		fmt.Printf("Invalid format for username or password. Both name and key are required.\n")
+	usernameName, usernameKey, passwordName, passwordKey, err := validateSecretKeySelector(username, password)
+	if err != nil {
+		fmt.Println(err)
 		return
 	}
 

--- a/cyctl/internal/create/template_auth_rules.go
+++ b/cyctl/internal/create/template_auth_rules.go
@@ -28,7 +28,6 @@ var (
 
 // createTemplateAuthRule allows you to create create TemplateAuthRule Custom Resource.
 func createTemplateAuthRule(clientset *client.CyclopsV1Alpha1Client, templateAuthRuleName string) {
-	_ = clientset
 	usernameSlice := strings.Split(username, ":")
 	passwordSlice := strings.Split(password, ":")
 

--- a/cyctl/internal/create/template_auth_rules.go
+++ b/cyctl/internal/create/template_auth_rules.go
@@ -1,0 +1,112 @@
+package create
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cyclops-ui/cyclops/cyclops-ctrl/api/v1alpha1"
+	"github.com/cyclops-ui/cyclops/cyclops-ctrl/api/v1alpha1/client"
+	"github.com/cyclops-ui/cycops-cyctl/internal/kubeconfig"
+	"github.com/spf13/cobra"
+	v1Spec "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	createTemplateAuthRuleExample = ` 
+	# Create templateauth rule
+	cyctl create templateauthrule NAME --repo='github.com/repo/a' --username='name:key' --password='name:key'
+ 
+	# Create templateauthrule
+	cyctl create templateauthrule demo-templateauthrule --repo='https://github.com/cyclops-ui/templates' --username='name:john' --password='name:random'`
+)
+
+var (
+	username string
+	password string
+)
+
+// createTemplateAuthRule allows you to create create TemplateAuthRule Custom Resource.
+func createTemplateAuthRule(clientset *client.CyclopsV1Alpha1Client, templateAuthRuleName string) {
+	_ = clientset
+	usernameSlice := strings.Split(username, ":")
+	passwordSlice := strings.Split(password, ":")
+
+	// Ensure key is present for both username and password
+	if len(usernameSlice) < 2 || usernameSlice[1] == "" || len(passwordSlice) < 2 || passwordSlice[1] == "" {
+		fmt.Printf("Invalid format for username or password. Expected 'name:key'.\n")
+		return
+	}
+
+	usernameKey, passwordKey := usernameSlice[1], passwordSlice[1]
+	var usernameName, passwordName string
+	if len(usernameSlice) > 1 {
+		usernameName = usernameSlice[0]
+	}
+	if len(passwordSlice) > 1 {
+		passwordName = passwordSlice[0]
+	}
+
+	var localObjectNameRef, localObjectPasswordRef v1Spec.LocalObjectReference
+	if usernameName != "" {
+		localObjectNameRef = v1Spec.LocalObjectReference{
+			Name: usernameName,
+		}
+	}
+	if passwordName != "" {
+		localObjectPasswordRef = v1Spec.LocalObjectReference{
+			Name: passwordName,
+		}
+	}
+
+	newTemplateAuthRule := v1alpha1.TemplateAuthRule{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "cyclops-ui.com/v1alpha1",
+			Kind:       "TemplateAuthRule",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      templateAuthRuleName,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.TemplateAuthRuleSpec{
+			Repo: repo,
+			Username: v1Spec.SecretKeySelector{
+				Key:                  usernameKey,
+				LocalObjectReference: localObjectNameRef,
+			},
+			Password: v1Spec.SecretKeySelector{
+				Key:                  passwordKey,
+				LocalObjectReference: localObjectPasswordRef,
+			},
+		},
+	}
+
+	templateAuthRule, err := clientset.TemplateAuthRules(namespace).Create(&newTemplateAuthRule)
+	if err != nil {
+		fmt.Printf("Error creating templateauthrule: %v\n", err)
+		return
+	}
+	fmt.Printf("%v created successfully.\n", templateAuthRule.Name)
+
+}
+
+var (
+	CreateTemplateAuthRule = &cobra.Command{
+		Use:     "templateauthrules NAME --username='name:key' --password='name:key'",
+		Short:   "Create templateauthrules",
+		Long:    "The create templateauthrules command allows you to create templateauthrules from the Cyclops API.",
+		Example: createTemplateAuthRuleExample,
+		Args:    cobra.ExactArgs(1),
+		Aliases: []string{"templateauthrule"},
+		Run: func(cmd *cobra.Command, args []string) {
+			createTemplateAuthRule(kubeconfig.Moduleset, args[0])
+		},
+	}
+)
+
+func init() {
+	CreateTemplateAuthRule.Flags().StringVarP(&repo, "repo", "r", "", "Repository URL of the template")
+	CreateTemplateAuthRule.Flags().StringVarP(&username, "username", "u", "", "Username in the format 'name:key'")
+	CreateTemplateAuthRule.Flags().StringVarP(&password, "password", "p", "", "Password in the format 'name:key'")
+	CreateTemplateAuthRule.Flags().StringVarP(&namespace, "namespace", "n", "cyclops", "Namespace where the templateauthrule will be created")
+}

--- a/cyctl/internal/create/template_store.go
+++ b/cyctl/internal/create/template_store.go
@@ -1,0 +1,76 @@
+package create
+
+import (
+	"fmt"
+
+	"github.com/cyclops-ui/cyclops/cyclops-ctrl/api/v1alpha1"
+	"github.com/cyclops-ui/cyclops/cyclops-ctrl/api/v1alpha1/client"
+	"github.com/cyclops-ui/cycops-cyctl/internal/kubeconfig"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	createTemplateExample = ` 
+ # Create template
+ cyctl create template NAME --repo='github.com/repo/a' --path='/path/to/charts'
+ 
+ # Create template sample command
+ cyctl create template NAME --repo='https://github.com/cyclops-ui/templates' --path='/path' --version='main'`
+)
+
+var (
+	// path to charts
+	path string
+
+	// charts version
+	version string
+)
+
+// DeleteTemplateAuthRule deletes a specified template auth rule from the TemplateAuthRule Custom Resource.
+func createTemplate(clientset *client.CyclopsV1Alpha1Client, templateName, path, version, namespace string) {
+	// Define a new TemplateStore object
+	newTemplate := v1alpha1.TemplateStore{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "cyclops-ui.com/v1alpha1",
+			Kind:       "TemplateStore",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      templateName,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.TemplateRef{
+			URL:     repo,
+			Path:    path,
+			Version: version,
+		},
+	}
+
+	template, err := clientset.TemplateStore(namespace).Create(&newTemplate)
+	if err != nil {
+		fmt.Printf("Error creating template: %v\n", err)
+		return
+	}
+	fmt.Printf("%v created successfully.\n", template.Name)
+}
+
+var (
+	CreateTemplate = &cobra.Command{
+		Use:     "templates NAME --repo=repo --path=path --version=version",
+		Short:   "Create template",
+		Long:    "The create template command allows you to create templatestore from the Cyclops API.",
+		Example: createTemplateExample,
+		Args:    cobra.ExactArgs(1),
+		Aliases: []string{"template"},
+		Run: func(cmd *cobra.Command, args []string) {
+			createTemplate(kubeconfig.Moduleset, args[0], path, version, namespace)
+		},
+	}
+)
+
+func init() {
+	CreateTemplate.Flags().StringVarP(&repo, "repo", "r", "", "Repository URL of the template")
+	CreateTemplate.Flags().StringVarP(&path, "path", "p", "", "Path to the charts in the repository")
+	CreateTemplate.Flags().StringVarP(&version, "version", "v", "", "Version of the template")
+	CreateTemplate.Flags().StringVarP(&namespace, "namespace", "n", "cyclops", "Namespace where the template will be created")
+}


### PR DESCRIPTION
closes #298 and #296 

## 📑 Description

Available commands for creating templatestore custom resources
```bash
cyctl create template demo-template-5 -r 'github.com/sidhant/random' -p '/path'

cyctl create template demo-template-5 -r 'github.com/sidhant/random' -p '/path' --version 'main'

cyctl create template demo-template-5 \
 -r 'github.com/sidhant/random' \  
 -p '/path' \
 -v 'main' \
 -n default
```

Available commands for creating templateauthrule custom resources
```bash
cyctl create templateauthrule NAME \ 
--username='name:key' \
--password='name:passkey' \ 
--repo='github.com/github/demo' \


cyctl create templateauthrule templateauth3 \ 
--username='dextor:john' \
--password=':pass' \ 
--repo='github.com/github/demo' 


cyctl create templateauthrule templateauth3 \ 
--username=':john' \
--password=':pass' \ 
--repo='github.com/github/demo' \
-n default


```

