### PR TITLE
Added a method for handling DaemonSets

### DIFF
--- a/cyclops-ctrl/internal/cluster/k8sclient/client.go
+++ b/cyclops-ctrl/internal/cluster/k8sclient/client.go
@@ -272,6 +272,8 @@ func (k *KubernetesClient) GetResource(group, version, kind, name, namespace str
 	switch {
 	case isDeployment(group, version, kind):
 		return k.mapDeployment(group, version, kind, name, namespace)
+	case isDaemonSet(group, version, kind):
+		return k.mapDaemonSet(group, version, kind, name, namespace)
 	case isService(group, version, kind):
 		return k.mapService(group, version, kind, name, namespace)
 	case isStatefulSet(group, version, kind):
@@ -460,6 +462,23 @@ func (k *KubernetesClient) mapDeployment(group, version, kind, name, namespace s
 		Replicas:  int(*deployment.Spec.Replicas),
 		Pods:      pods,
 		Status:    getDeploymentStatus(pods),
+	}, nil
+}
+
+func (k *KubernetesClient) mapDaemonSet(group, version, kind, name, namespace string) (*dto.DaemonSet, error) {
+	daemonSet, err := k.clientset.AppsV1().DaemonSets(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO pods handling
+
+	return &dto.DaemonSet{
+		Group:     group,
+		Version:   version,
+		Kind:      kind,
+		Name:      daemonSet.Name,
+		Namespace: daemonSet.Namespace,
 	}, nil
 }
 
@@ -657,6 +676,10 @@ func (k *KubernetesClient) isResourceNamespaced(gvk schema.GroupVersionKind) (bo
 
 func isDeployment(group, version, kind string) bool {
 	return group == "apps" && version == "v1" && kind == "Deployment"
+}
+
+func isDaemonSet(group, version, kind string) bool {
+	return group == "apps" && version == "v1" && kind == "DaemonSet"
 }
 
 func isStatefulSet(group, version, kind string) bool {

--- a/cyclops-ctrl/internal/models/dto/k8s.go
+++ b/cyclops-ctrl/internal/models/dto/k8s.go
@@ -60,6 +60,49 @@ func (d *Deployment) SetDeleted(deleted bool) {
 	d.Deleted = deleted
 }
 
+type DaemonSet struct {
+	Group     string `json:"group"`
+	Version   string `json:"version"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Pods      []Pod  `json:"pods"`
+	Status    bool   `json:"status"`
+	Deleted   bool   `json:"deleted"`
+}
+
+func (d *DaemonSet) GetGroupVersionKind() string {
+	return d.Group + "/" + d.Version + ", Kind=" + d.Kind
+}
+
+func (d *DaemonSet) GetGroup() string {
+	return d.Group
+}
+
+func (d *DaemonSet) GetVersion() string {
+	return d.Version
+}
+
+func (d *DaemonSet) GetKind() string {
+	return d.Kind
+}
+
+func (d *DaemonSet) GetName() string {
+	return d.Name
+}
+
+func (d *DaemonSet) GetNamespace() string {
+	return d.Namespace
+}
+
+func (d *DaemonSet) GetDeleted() bool {
+	return d.Deleted
+}
+
+func (d *DaemonSet) SetDeleted(deleted bool) {
+	d.Deleted = deleted
+}
+
 type Service struct {
 	Group     string           `json:"group"`
 	Version   string           `json:"version"`


### PR DESCRIPTION
This pull request introduces a new method `mapDaemonSet` to handle DaemonSets. This method fetches DaemonSet details and maps them to a DTO object.

### Changes
- Added `mapDaemonSet` method to `KubernetesClient`
- Created `dto.DaemonSet` struct along with its methods (`GetGroupVersionKind`, `GetGroup`, `GetVersion`, `GetKind`, `GetName`, `GetNamespace`, `GetDeleted`, `SetDeleted`)