### PR TITLE
feat(ui): add component for PersistentVolumeClaim

### DIFF
--- a/cyclops-ui/src/components/k8s-resources/PersistentVolumeClaim.tsx
+++ b/cyclops-ui/src/components/k8s-resources/PersistentVolumeClaim.tsx
@@ -1,0 +1,93 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+import { mapResponseError } from "../../utils/api/errors";
+import { Alert, Descriptions, Divider } from "antd";
+
+interface Props {
+  name: string;
+  namespace: string;
+}
+
+interface pvc {
+  size: string;
+  accessModes: string;
+}
+
+const PersistentVolumeClaim = ({ name, namespace }: Props) => {
+  const [pvc, setPvc] = useState<pvc>({
+    size: "",
+    accessModes: "",
+  });
+  const [error, setError] = useState({
+    message: "",
+    description: "",
+  });
+
+  useEffect(() => {
+    // Move function to useEffect to avoid es-lint React Hook useEffect has a missing dependency
+    // Ref: https://stackoverflow.com/questions/55840294/how-to-fix-missing-dependency-warning-when-using-useeffect-react-hook
+    // Ref: https://github.com/facebook/react/issues/14920
+    function fetchPersistentVolumeClaim() {
+      axios
+        .get(`/api/resources`, {
+          params: {
+            group: ``,
+            version: `v1`,
+            kind: `PersistentVolumeClaim`,
+            name: name,
+            namespace: namespace,
+          },
+        })
+        .then((res) => {
+          setPvc({
+            size: res.data.size,
+            accessModes: res.data.accessmodes.join(","),
+          });
+        })
+        .catch((error) => {
+          setError(mapResponseError(error));
+        });
+    }
+
+    fetchPersistentVolumeClaim();
+    const interval = setInterval(() => fetchPersistentVolumeClaim(), 15000);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [name, namespace]);
+
+  return (
+    <div>
+      {error.message.length !== 0 && (
+        <Alert
+          message={error.message}
+          description={error.description}
+          type="error"
+          closable
+          afterClose={() => {
+            setError({
+              message: "",
+              description: "",
+            });
+          }}
+          style={{ marginBottom: "20px" }}
+        />
+      )}
+      <Divider />
+      <Descriptions style={{ width: "100%" }} bordered>
+        {Object.entries(pvc).map(([key, dataValue]) => (
+          <Descriptions.Item
+            key={key}
+            labelStyle={{ width: "20%" }}
+            label={key}
+            span={24}
+          >
+            {dataValue}
+          </Descriptions.Item>
+        ))}
+      </Descriptions>
+    </div>
+  );
+};
+
+export default PersistentVolumeClaim;

--- a/cyclops-ui/src/components/k8s-resources/PersistentVolumeClaim.tsx
+++ b/cyclops-ui/src/components/k8s-resources/PersistentVolumeClaim.tsx
@@ -24,9 +24,6 @@ const PersistentVolumeClaim = ({ name, namespace }: Props) => {
   });
 
   useEffect(() => {
-    // Move function to useEffect to avoid es-lint React Hook useEffect has a missing dependency
-    // Ref: https://stackoverflow.com/questions/55840294/how-to-fix-missing-dependency-warning-when-using-useeffect-react-hook
-    // Ref: https://github.com/facebook/react/issues/14920
     function fetchPersistentVolumeClaim() {
       axios
         .get(`/api/resources`, {

--- a/cyclops-ui/src/components/pages/ModuleDetails.tsx
+++ b/cyclops-ui/src/components/pages/ModuleDetails.tsx
@@ -21,7 +21,6 @@ import {
   CaretRightOutlined,
   CheckCircleTwoTone,
   CloseSquareTwoTone,
-  LinkOutlined,
   SearchOutlined,
   WarningTwoTone,
 } from "@ant-design/icons";
@@ -34,6 +33,8 @@ import StatefulSet from "../k8s-resources/StatefulSet";
 import Pod from "../k8s-resources/Pod";
 import Service from "../k8s-resources/Service";
 import ConfigMap from "../k8s-resources/ConfigMap";
+import PersistentVolumeClaim from "../k8s-resources/PersistentVolumeClaim";
+
 import {
   moduleTemplateReferenceView,
   templateRef,
@@ -393,6 +394,14 @@ const ModuleDetails = () => {
       case "ConfigMap":
         resourceDetails = (
           <ConfigMap name={resource.name} namespace={resource.namespace} />
+        );
+        break;
+      case "PersistentVolumeClaim":
+        resourceDetails = (
+          <PersistentVolumeClaim
+            name={resource.name}
+            namespace={resource.namespace}
+          />
         );
         break;
     }


### PR DESCRIPTION
closes #270 

## 📑 Description

This PR adds a component for displaying Persistent Volumen Claims

## ✅ Checks
- [ ] I have updated the documentation as required
- [ ] I have performed a self-review of my code

## ℹ Additional context

Here's a screenshot of the new component in action. I think that only size and access modes are the relevant information to be displayed.

![image](https://github.com/cyclops-ui/cyclops/assets/30386061/eda058aa-4ac9-46d7-b296-d7e013784801)

As this is my first contribution to the project don't hesitate to point me to any changes and improvements required for better PRs