### PR TITLE
fixed isuue-340 : implemented resource deatils for cronjob

### DIFF
--- a/cyclops-ctrl/internal/cluster/k8sclient/client.go
+++ b/cyclops-ctrl/internal/cluster/k8sclient/client.go
@@ -286,6 +286,8 @@ func (k *KubernetesClient) GetResource(group, version, kind, name, namespace str
 		return k.mapPersistentVolumeClaims(group, version, kind, name, namespace)
 	case isSecret(group, version, kind):
 		return k.mapSecret(group, version, kind, name, namespace)
+	case isCronJob(group, version, kind):
+		return k.mapCronJob(group, version, kind, name, namespace)
 	}
 
 	return nil, nil
@@ -685,6 +687,33 @@ func (k *KubernetesClient) mapSecret(group, version, kind, name, namespace strin
 	}, nil
 }
 
+func (k *KubernetesClient) mapCronJob(group, version, kind, name, namespace string) (*dto.CronJob, error) {
+	cronJob, err := k.clientset.BatchV1().CronJobs(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	pods, err := k.getPodsForCronJob(*cronJob)
+	if err != nil {
+		return nil, err
+	}
+
+	status := dto.StatusCronJob{
+		LastScheduleTime:   cronJob.Status.LastScheduleTime,
+		LastSuccessfulTime: cronJob.Status.LastSuccessfulTime,
+	}
+
+	return &dto.CronJob{
+		Group:     group,
+		Version:   version,
+		Kind:      kind,
+		Name:      cronJob.Name,
+		Namespace: cronJob.Namespace,
+		Schedule:  cronJob.Spec.Schedule,
+		Status:    status,
+		Pods:      pods,
+	}, nil
+}
+
 func (k *KubernetesClient) isResourceNamespaced(gvk schema.GroupVersionKind) (bool, error) {
 	resourcesList, err := k.discovery.ServerPreferredResources()
 	if err != nil {
@@ -743,4 +772,8 @@ func isPersistentVolumeClaims(group, version, kind string) bool {
 
 func isSecret(group, version, kind string) bool {
 	return group == "" && version == "v1" && kind == "Secret"
+}
+
+func isCronJob(group, version, kind string) bool {
+	return group == "batch" && version == "v1" && kind == "CronJob"
 }

--- a/cyclops-ctrl/internal/cluster/k8sclient/modules.go
+++ b/cyclops-ctrl/internal/cluster/k8sclient/modules.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -465,6 +466,54 @@ func (k *KubernetesClient) getStatefulsetPods(deployment appsv1.StatefulSet) ([]
 			Node:           item.Spec.NodeName,
 			PodPhase:       string(item.Status.Phase),
 			Started:        item.Status.StartTime,
+		})
+	}
+
+	return out, nil
+}
+
+func (k *KubernetesClient) getPodsForCronJob(cronJob batchv1.CronJob) ([]dto.Pod, error) {
+	jobTemplateLabels := cronJob.Spec.JobTemplate.Spec.Template.Labels
+	labelSelector := labels.SelectorFromSet(jobTemplateLabels).String()
+	pods, err := k.clientset.CoreV1().Pods(cronJob.Namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]dto.Pod, 0, len(pods.Items))
+	for _, item := range pods.Items {
+		containers := make([]dto.Container, 0, len(item.Spec.Containers))
+
+		for _, cnt := range item.Spec.Containers {
+			env := make(map[string]string)
+			for _, envVar := range cnt.Env {
+				env[envVar.Name] = envVar.Value
+			}
+
+			var status apiv1.ContainerStatus
+			for _, c := range item.Status.ContainerStatuses {
+				if c.Name == cnt.Name {
+					status = c
+					break
+				}
+			}
+
+			containers = append(containers, dto.Container{
+				Name:   cnt.Name,
+				Image:  cnt.Image,
+				Env:    env,
+				Status: containerStatus(status),
+			})
+		}
+
+		out = append(out, dto.Pod{
+			Name:       item.Name,
+			Containers: containers,
+			Node:       item.Spec.NodeName,
+			PodPhase:   string(item.Status.Phase),
+			Started:    item.Status.StartTime,
 		})
 	}
 

--- a/cyclops-ctrl/internal/cluster/k8sclient/modules.go
+++ b/cyclops-ctrl/internal/cluster/k8sclient/modules.go
@@ -474,50 +474,66 @@ func (k *KubernetesClient) getStatefulsetPods(deployment appsv1.StatefulSet) ([]
 
 func (k *KubernetesClient) getPodsForCronJob(cronJob batchv1.CronJob) ([]dto.Pod, error) {
 	jobTemplateLabels := cronJob.Spec.JobTemplate.Spec.Template.Labels
-	labelSelector := labels.SelectorFromSet(jobTemplateLabels).String()
-	pods, err := k.clientset.CoreV1().Pods(cronJob.Namespace).List(context.Background(), metav1.ListOptions{
-		LabelSelector: labelSelector,
+	jobLabelSelector := labels.SelectorFromSet(jobTemplateLabels).String()
+
+	jobs, err := k.clientset.BatchV1().Jobs(cronJob.Namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: jobLabelSelector,
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	out := make([]dto.Pod, 0, len(pods.Items))
-	for _, item := range pods.Items {
-		containers := make([]dto.Container, 0, len(item.Spec.Containers))
+	out := make([]dto.Pod, 0)
 
-		for _, cnt := range item.Spec.Containers {
-			env := make(map[string]string)
-			for _, envVar := range cnt.Env {
-				env[envVar.Name] = envVar.Value
-			}
+	for _, job := range jobs.Items {
+		podTemplateLabels := job.Spec.Template.Labels
+		podLabelSelector := labels.SelectorFromSet(podTemplateLabels).String()
 
-			var status apiv1.ContainerStatus
-			for _, c := range item.Status.ContainerStatuses {
-				if c.Name == cnt.Name {
-					status = c
-					break
-				}
-			}
+		pods, err := k.clientset.CoreV1().Pods(cronJob.Namespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: podLabelSelector,
+		})
 
-			containers = append(containers, dto.Container{
-				Name:   cnt.Name,
-				Image:  cnt.Image,
-				Env:    env,
-				Status: containerStatus(status),
-			})
+		if err != nil {
+			return nil, err
 		}
 
-		out = append(out, dto.Pod{
-			Name:       item.Name,
-			Containers: containers,
-			Node:       item.Spec.NodeName,
-			PodPhase:   string(item.Status.Phase),
-			Started:    item.Status.StartTime,
-		})
+		for _, item := range pods.Items {
+			containers := make([]dto.Container, 0, len(item.Spec.Containers))
+
+			for _, cnt := range item.Spec.Containers {
+				env := make(map[string]string)
+				for _, envVar := range cnt.Env {
+					env[envVar.Name] = envVar.Value
+				}
+
+				var status apiv1.ContainerStatus
+				for _, c := range item.Status.ContainerStatuses {
+					if c.Name == cnt.Name {
+						status = c
+						break
+					}
+				}
+
+				containers = append(containers, dto.Container{
+					Name:   cnt.Name,
+					Image:  cnt.Image,
+					Env:    env,
+					Status: containerStatus(status),
+				})
+			}
+
+			out = append(out, dto.Pod{
+				Name:       item.Name,
+				Containers: containers,
+				Node:       item.Spec.NodeName,
+				PodPhase:   string(item.Status.Phase),
+				Started:    item.Status.StartTime,
+			})
+		}
 	}
 
 	return out, nil
+
 }
 
 func containerStatus(status apiv1.ContainerStatus) dto.ContainerStatus {

--- a/cyclops-ctrl/internal/models/dto/k8s.go
+++ b/cyclops-ctrl/internal/models/dto/k8s.go
@@ -385,6 +385,70 @@ func (s *Secret) SetDeleted(deleted bool) {
 	s.Deleted = deleted
 }
 
+type StatusCronJob struct {
+	LastScheduleTime   *metav1.Time `json:"lastScheduleTime"`
+	LastSuccessfulTime *metav1.Time `json:"lastSuccessfulTime"`
+}
+
+func (s *StatusCronJob) GetLastScheduleTime() string {
+	if s.LastScheduleTime != nil {
+		return s.LastScheduleTime.String()
+	}
+	return ""
+}
+
+func (s *StatusCronJob) GetLastSuccessfulTime() string {
+	if s.LastSuccessfulTime != nil {
+		return s.LastSuccessfulTime.String()
+	}
+	return ""
+}
+
+type CronJob struct {
+	Group     string        `json:"group"`
+	Version   string        `json:"version"`
+	Kind      string        `json:"kind"`
+	Name      string        `json:"name"`
+	Namespace string        `json:"namespace"`
+	Pods      []Pod         `json:"pods"`
+	Schedule  string        `json:"schedule"`
+	Status    StatusCronJob `json:"status"`
+	Suspend   bool          `json:"suspend"`
+	Deleted   bool          `json:"deleted"`
+}
+
+func (c *CronJob) GetGroupVersionKind() string {
+	return c.Group + "/" + c.Version + ", Kind=" + c.Kind
+}
+
+func (c *CronJob) GetGroup() string {
+	return c.Group
+}
+
+func (c *CronJob) GetVersion() string {
+	return c.Version
+}
+
+func (c *CronJob) GetKind() string {
+	return c.Kind
+}
+
+func (c *CronJob) GetName() string {
+	return c.Name
+}
+
+func (c *CronJob) GetNamespace() string {
+	return c.Namespace
+}
+
+func (c *CronJob) GetDeleted() bool {
+	return c.Deleted
+}
+
+func (c *CronJob) SetDeleted(deleted bool) {
+	c.Deleted = deleted
+}
+
 type Other struct {
 	Group     string `json:"group"`
 	Version   string `json:"version"`


### PR DESCRIPTION
closes # 340

## 📑 Description
Implemented resource details for CronJob. The API response now includes pods (managed by CronJobs), schedule, status, and other relevant information. The fetch endpoint is 
/resources?group=batch&version=v1&kind=CronJob&name=<name>&namespace=<namespace>

## ✅ Checks
- [ ] I have updated the documentation as required
- [x] I have performed a self-review of my code

## ℹ Additional context

I have tested the code. See the attached screenshots for reference.

![Screenshot 2024-06-17 at 9 25 11 PM](https://github.com/cyclops-ui/cyclops/assets/6430569/afbc4fcb-27e5-4d79-802b-d5409723190c)


