### PR TITLE
fix:implement resource details for Jobs

### DIFF
--- a/cyclops-ctrl/internal/cluster/k8sclient/modules.go
+++ b/cyclops-ctrl/internal/cluster/k8sclient/modules.go
@@ -536,6 +536,55 @@ func (k *KubernetesClient) getPodsForCronJob(cronJob batchv1.CronJob) ([]dto.Pod
 
 }
 
+func (k *KubernetesClient) getPodsForJob(job batchv1.Job) ([]dto.Pod, error) {
+
+	pods, err := k.clientset.CoreV1().Pods(job.Namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.Set(job.Spec.Selector.MatchLabels).String(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]dto.Pod, 0, len(pods.Items))
+	for _, item := range pods.Items {
+		containers := make([]dto.Container, 0, len(item.Spec.Containers))
+
+		for _, cnt := range item.Spec.Containers {
+			env := make(map[string]string)
+			for _, envVar := range cnt.Env {
+				env[envVar.Name] = envVar.Value
+			}
+
+			var status apiv1.ContainerStatus
+			for _, c := range item.Status.ContainerStatuses {
+				if c.Name == cnt.Name {
+					status = c
+					break
+				}
+			}
+
+			containers = append(containers, dto.Container{
+				Name:   cnt.Name,
+				Image:  cnt.Image,
+				Env:    env,
+				Status: containerStatus(status),
+			})
+		}
+
+		out = append(out, dto.Pod{
+			Name:       item.Name,
+			Containers: containers,
+			Node:       item.Spec.NodeName,
+			PodPhase:   string(item.Status.Phase),
+			Started:    item.Status.StartTime,
+		})
+	}
+
+	return out, nil
+
+}
+
 func containerStatus(status apiv1.ContainerStatus) dto.ContainerStatus {
 	if status.State.Waiting != nil {
 		return dto.ContainerStatus{

--- a/cyclops-ctrl/internal/models/dto/k8s.go
+++ b/cyclops-ctrl/internal/models/dto/k8s.go
@@ -449,6 +449,49 @@ func (c *CronJob) SetDeleted(deleted bool) {
 	c.Deleted = deleted
 }
 
+type Job struct {
+	Group          string `json:"group"`
+	Version        string `json:"version"`
+	Kind           string `json:"kind"`
+	Name           string `json:"name"`
+	Namespace      string `json:"namespace"`
+	Pods           []Pod  `json:"pods"`
+	CompletionTime string `json:"completionTime"`
+	StartTime      string `json:"startTime"`
+}
+
+func (c *Job) GetGroupVersionKind() string {
+	return c.Group + "/" + c.Version + ", Kind=" + c.Kind
+}
+
+func (c *Job) GetGroup() string {
+	return c.Group
+}
+
+func (c *Job) GetVersion() string {
+	return c.Version
+}
+
+func (c *Job) GetKind() string {
+	return c.Kind
+}
+
+func (c *Job) GetName() string {
+	return c.Name
+}
+
+func (c *Job) GetNamespace() string {
+	return c.Namespace
+}
+
+func (c *Job) GetCompletionTime() string {
+	return c.CompletionTime
+}
+
+func (c *Job) GetStartTime() string {
+	return c.StartTime
+}
+
 type Other struct {
 	Group     string `json:"group"`
 	Version   string `json:"version"`


### PR DESCRIPTION
closes #339 

## 📑 Description

created new endpoint : /resources?group=batch&version=v1&kind=Job&name=<name>&namespace=<namespace>

It will response all details of job, start time , end time and details of pod related to it.


## ✅ Checks
- [X] I have updated the documentation as required
- [X] I have performed a self-review of my code

## ℹ Additional context

I have tested code. Screenshot for reference.

![Screenshot 2024-06-19 at 9 23 12 PM](https://github.com/cyclops-ui/cyclops/assets/6430569/a6e93a4d-5a01-4e17-867a-9dff50ef64ff)

