### PR TITLE
Namespace in module header

### DIFF
--- a/cyclops-ui/src/components/k8s-resources/Service.tsx
+++ b/cyclops-ui/src/components/k8s-resources/Service.tsx
@@ -80,7 +80,13 @@ const Service = ({ name, namespace }: Props) => {
               title="Name"
               dataIndex="name"
               key="name"
-              render={(text) => (text ? text : "not set")}
+              render={(text) =>
+                text ? (
+                  text
+                ) : (
+                  <span style={{ color: "#A0A0A0" }}>{"<not set>"}</span>
+                )
+              }
             />
             <Table.Column title="Protocol" dataIndex="protocol" />
             <Table.Column title="Port" dataIndex="port" />

--- a/cyclops-ui/src/components/k8s-resources/Service.tsx
+++ b/cyclops-ui/src/components/k8s-resources/Service.tsx
@@ -41,6 +41,7 @@ const Service = ({ name, namespace }: Props) => {
       })
       .then((res) => {
         setService(res.data);
+        console.log(res.data);
       })
       .catch((error) => {
         setError(mapResponseError(error));
@@ -76,7 +77,12 @@ const Service = ({ name, namespace }: Props) => {
       <Row>
         <Col span={24} style={{ overflowX: "auto" }}>
           <Table dataSource={service.ports}>
-            <Table.Column title="Name" dataIndex="name" key="name" />
+            <Table.Column
+              title="Name"
+              dataIndex="name"
+              key="name"
+              render={(text) => (text ? text : "not set")}
+            />
             <Table.Column title="Protocol" dataIndex="protocol" />
             <Table.Column title="Port" dataIndex="port" />
             <Table.Column title="Target port" dataIndex="targetPort" />

--- a/cyclops-ui/src/components/k8s-resources/Service.tsx
+++ b/cyclops-ui/src/components/k8s-resources/Service.tsx
@@ -41,7 +41,6 @@ const Service = ({ name, namespace }: Props) => {
       })
       .then((res) => {
         setService(res.data);
-        console.log(res.data);
       })
       .catch((error) => {
         setError(mapResponseError(error));

--- a/cyclops-ui/src/components/pages/ModuleDetails.tsx
+++ b/cyclops-ui/src/components/pages/ModuleDetails.tsx
@@ -512,7 +512,9 @@ const ModuleDetails = () => {
           </Col>
         </Row>
         <Row>
-          <Title level={4}>{resource.namespace}</Title>
+          <Title level={4}>
+            {resource.namespace === "default" ? "not set" : resource.namespace}
+          </Title>
         </Row>
         <Row>
           <Col style={{ float: "right" }}>

--- a/cyclops-ui/src/components/pages/ModuleDetails.tsx
+++ b/cyclops-ui/src/components/pages/ModuleDetails.tsx
@@ -579,7 +579,10 @@ const ModuleDetails = () => {
           </Row>
           <Row gutter={[40, 0]}>
             <Col span={9}>
-              <Title level={3}>{module.namespace}</Title>
+              <Title level={3}>
+                {"Namespace: "}
+                {module.namespace}
+              </Title>
             </Col>
           </Row>
           <Row gutter={[40, 0]}>

--- a/cyclops-ui/src/components/pages/ModuleDetails.tsx
+++ b/cyclops-ui/src/components/pages/ModuleDetails.tsx
@@ -512,9 +512,7 @@ const ModuleDetails = () => {
           </Col>
         </Row>
         <Row>
-          <Title level={4}>
-            {resource.namespace === "default" ? "not set" : resource.namespace}
-          </Title>
+          <Title level={4}>{resource.namespace}</Title>
         </Row>
         <Row>
           <Col style={{ float: "right" }}>


### PR DESCRIPTION
closes #365 

## 📑 Description
`Namespace:` is added in the Module Header before the  `module.namespace` for users to understand what the `module.namespace` actually is 
 ## ✅ Checks
- [x] I have performed a self-review of my code

## ℹ Additional context
Here is a screenshot of the changes 
![image](https://github.com/cyclops-ui/cyclops/assets/124070023/1190ac5d-551e-49c4-ab5d-bbc9e5bbf5d1)

