### PR TITLE
Disable Download Log Button When No Logs Are Available

### DIFF
--- a/cyclops-ui/src/components/k8s-resources/common/PodTable.tsx
+++ b/cyclops-ui/src/components/k8s-resources/common/PodTable.tsx
@@ -74,6 +74,7 @@ const PodTable = ({ pods, namespace }: Props) => {
                 type="primary"
                 // icon={<DownloadOutlined />}
                 onClick={downloadLogs(container.name)}
+                disabled={logs === "No logs available"}
               >
                 Download
               </Button>
@@ -101,6 +102,7 @@ const PodTable = ({ pods, namespace }: Props) => {
                 type="primary"
                 // icon={<DownloadOutlined />}
                 onClick={downloadLogs(container.name)}
+                disabled={logs === "No logs available"}
               >
                 Download
               </Button>


### PR DESCRIPTION
closes #369 

## 📑 Description
This PR disables the download log button when no logs are available. I have attached screenshots below:

### When no logs are available:
![image](https://github.com/cyclops-ui/cyclops/assets/74239252/3f312c5d-ee9f-4b6a-9a6e-5130410ef0a9)

### When logs are available:
![image](https://github.com/cyclops-ui/cyclops/assets/74239252/0f0ef2d4-953c-49f2-b863-800c2b78ae3e)

## ✅ Checks
- [ ] I have updated the documentation as required
- [x] I have performed a self-review of my code

## ℹ Additional context
- The changes are made only within the PodTable.tsx component