### PR TITLE
fix #425: show module name on delete modal

### DIFF
--- a/cyclops-ui/src/components/pages/ModuleDetails.tsx
+++ b/cyclops-ui/src/components/pages/ModuleDetails.tsx
@@ -868,7 +868,7 @@ const ModuleDetails = () => {
       </Divider>
       {resourcesLoading()}
       <Modal
-        title="Delete module"
+        title={`Delete module ${moduleName}`}
         open={loading}
         onCancel={handleCancel}
         width={"40%"}


### PR DESCRIPTION
closes #425

## 📑 Description
It adds module name on deleting modal view.


## ✅ Checks
- [ ] I have updated the documentation as required
- [x] I have performed a self-review of my code

## ℹ Additional context
It adds module name on deleting modal view. So that user can see what they are deleting.