### PR TITLE
🚀 feat: ant design gauges for node details & updated condition cards with icons

### DIFF
--- a/cyclops-ui/package.json
+++ b/cyclops-ui/package.json
@@ -31,7 +31,6 @@
     "react-code-blocks": "^0.1.3",
     "react-diff-viewer": "^3.1.1",
     "react-dom": "^18.0.0",
-    "react-gauge-component": "^1.1.22",
     "react-highlight-words": "^0.17.0",
     "react-router-dom": "^6.21.1",
     "react-scripts": "^5.0.1",

--- a/cyclops-ui/src/components/pages/NodeDetails.tsx
+++ b/cyclops-ui/src/components/pages/NodeDetails.tsx
@@ -11,12 +11,12 @@ import {
   Space,
   Table,
   Typography,
+  Progress,
 } from "antd";
 import "ace-builds/src-noconflict/ace";
 import { useParams } from "react-router-dom";
 import axios from "axios";
 import "ace-builds/src-noconflict/mode-jsx";
-import GaugeComponent from "react-gauge-component";
 import type { InputRef } from "antd";
 import { formatBytes } from "../../utils/common";
 import { ColumnType } from "antd/lib/table";
@@ -274,7 +274,10 @@ const NodeDetails = () => {
   useEffect(() => {
     const fetchNodeData = () => {
       axios
-        .get(`/api/nodes/` + nodeName)
+        .get(
+          `https://stunning-space-computing-machine-wxxpjrpr4v5fgqv6-3000.app.github.dev/api/nodes/` +
+            nodeName,
+        )
         .then((res) => {
           setNode(res.data);
           setResources({
@@ -340,20 +343,34 @@ const NodeDetails = () => {
       if (cond.type === type) {
         switch (type) {
           case "MemoryPressure":
-            return cond.status === "True" ? "#de3428" : "green";
+            return cond.status === "True"
+              ? gaugeColors["0%"]
+              : gaugeColors["100%"];
           case "DiskPressure":
-            return cond.status === "True" ? "#de3428" : "green";
+            return cond.status === "True"
+              ? gaugeColors["0%"]
+              : gaugeColors["100%"];
           case "PIDPressure":
-            return cond.status === "True" ? "#de3428" : "green";
+            return cond.status === "True"
+              ? gaugeColors["0%"]
+              : gaugeColors["100%"];
           case "Ready":
-            return cond.status === "True" ? "green" : "#de3428";
+            return cond.status === "True"
+              ? gaugeColors["100%"]
+              : gaugeColors["0%"];
           default:
             console.log("default", type);
         }
       }
     }
 
-    return "gray";
+    return gaugeColors["50%"];
+  };
+
+  const gaugeColors = {
+    "0%": "#57F287",
+    "50%": "#FEE75C",
+    "100%": "#ED4245",
   };
 
   return (
@@ -399,53 +416,47 @@ const NodeDetails = () => {
               width: "80%",
             }}
           >
-            <GaugeComponent
-              labels={{
-                valueLabel: {
-                  style: { fill: "#000", textShadow: "" },
-                  // formatTextValue: (value) => `CPU ${value}%`
-                },
-              }}
-              type={"grafana"}
-              value={resources.cpu * 100}
+            <Progress
+              type="dashboard"
+              strokeWidth={10}
+              status="normal"
+              percent={resources.cpu * 100}
+              strokeColor={gaugeColors}
             />
             <h1>
-              CPU ({node.requested.cpu}m / {node.available.cpu}m)
+              <strong>CPU</strong>
+              <br />({node.requested.cpu}m / {node.available.cpu}m)
             </h1>
           </div>
         </Col>
         <Col span={8}>
           <div style={{ textAlign: "center", width: "80%" }}>
-            <GaugeComponent
-              labels={{
-                valueLabel: {
-                  style: { fill: "#000", textShadow: "" },
-                  // formatTextValue: (value) => `memory ${value}%`
-                },
-              }}
-              type={"grafana"}
-              value={resources.memory * 100}
+            <Progress
+              type="dashboard"
+              strokeWidth={10}
+              status="normal"
+              percent={resources.memory * 100}
+              strokeColor={gaugeColors}
             />
             <h1>
-              Memory ({formatBytes(node.requested.memory)} /{" "}
+              <strong>Memory</strong>
+              <br />({formatBytes(node.requested.memory)} /{" "}
               {formatBytes(node.available.memory)})
             </h1>
           </div>
         </Col>
         <Col span={8}>
           <div style={{ textAlign: "center", width: "80%" }}>
-            <GaugeComponent
-              labels={{
-                valueLabel: {
-                  style: { fill: "#000", textShadow: "" },
-                  // formatTextValue: (value) => `pods ${value}%`
-                },
-              }}
-              type={"grafana"}
-              value={resources.pod_count * 100}
+            <Progress
+              type="dashboard"
+              strokeWidth={10}
+              status="normal"
+              percent={resources.pod_count * 100}
+              strokeColor={gaugeColors}
             />
             <h1>
-              Pods ({node.requested.pod_count} / {node.available.pod_count})
+              <strong>Pods</strong>
+              <br />({node.requested.pod_count} / {node.available.pod_count})
             </h1>
           </div>
         </Col>
@@ -469,14 +480,30 @@ const NodeDetails = () => {
           <Card
             style={{
               borderRadius: "10px",
-              backgroundColor: conditionColor("MemoryPressure"),
+              borderWidth: "5px",
+              backgroundColor: "#fff",
               width: "100%",
               margin: "5px",
               textAlign: "center",
-              color: "white",
+              color: "black",
             }}
           >
-            <h1 style={{ margin: "0" }}>MemoryPressure</h1>
+            <Progress
+              type="circle"
+              percent={100}
+              status={
+                conditionColor("MemoryPressure") === gaugeColors["100%"]
+                  ? "success"
+                  : "exception"
+              }
+              trailColor={conditionColor("MemoryPressure")}
+              strokeWidth={15}
+            />
+            <br />
+            <br />
+            <h3>
+              <strong>MemoryPressure</strong>
+            </h3>
           </Card>
         </Col>
         <Col
@@ -490,14 +517,30 @@ const NodeDetails = () => {
           <Card
             style={{
               borderRadius: "10px",
-              backgroundColor: conditionColor("DiskPressure"),
+              borderWidth: "5px",
+              backgroundColor: "#fff",
               width: "100%",
               margin: "5px",
               textAlign: "center",
-              color: "white",
+              color: "black",
             }}
           >
-            <h1 style={{ margin: "0" }}>DiskPressure</h1>
+            <Progress
+              type="circle"
+              percent={100}
+              status={
+                conditionColor("DiskPressure") === gaugeColors["100%"]
+                  ? "success"
+                  : "exception"
+              }
+              trailColor={conditionColor("DiskPressure")}
+              strokeWidth={15}
+            />
+            <br />
+            <br />
+            <h3>
+              <strong>DiskPressure</strong>
+            </h3>
           </Card>
         </Col>
         <Col
@@ -511,14 +554,30 @@ const NodeDetails = () => {
           <Card
             style={{
               borderRadius: "10px",
-              backgroundColor: conditionColor("PIDPressure"),
+              borderWidth: "5px",
+              backgroundColor: "#fff",
               width: "100%",
               margin: "5px",
               textAlign: "center",
-              color: "white",
+              color: "black",
             }}
           >
-            <h1 style={{ margin: "0" }}>PIDPressure</h1>
+            <Progress
+              type="circle"
+              percent={100}
+              status={
+                conditionColor("PIDPressure") === gaugeColors["100%"]
+                  ? "success"
+                  : "exception"
+              }
+              trailColor={conditionColor("PIDPressure")}
+              strokeWidth={15}
+            />
+            <br />
+            <br />
+            <h3>
+              <strong>PIDPressure</strong>
+            </h3>
           </Card>
         </Col>
         <Col
@@ -532,14 +591,30 @@ const NodeDetails = () => {
           <Card
             style={{
               borderRadius: "10px",
-              backgroundColor: conditionColor("Ready"),
+              borderWidth: "5px",
+              backgroundColor: "#fff",
               width: "100%",
               margin: "5px",
               textAlign: "center",
-              color: "white",
+              color: "black",
             }}
           >
-            <h1 style={{ margin: "0" }}>Ready</h1>
+            <Progress
+              type="circle"
+              percent={100}
+              status={
+                conditionColor("Ready") === gaugeColors["100%"]
+                  ? "success"
+                  : "exception"
+              }
+              trailColor={conditionColor("Ready")}
+              strokeWidth={15}
+            />
+            <br />
+            <br />
+            <h3>
+              <strong>Ready</strong>
+            </h3>
           </Card>
         </Col>
       </Row>

--- a/cyclops-ui/src/components/pages/NodeDetails.tsx
+++ b/cyclops-ui/src/components/pages/NodeDetails.tsx
@@ -398,7 +398,7 @@ const NodeDetails = () => {
       </Row>
       <Row>
         <Text keyboard>
-          Created On:-{" "}
+          Created on:-{" "}
           {new Date(
             node.node?.metadata?.creationTimestamp.toString(),
           ).toLocaleString()}
@@ -434,10 +434,12 @@ const NodeDetails = () => {
               percent={resources.cpu * 100}
               strokeColor={gaugeColors}
             />
-            <h1>
+            <h1 style={{ marginBottom: "6px" }}>
               <strong>CPU</strong>
-              <br />({node.requested.cpu}m / {node.available.cpu}m)
             </h1>
+            <h3>
+              ({node.requested.cpu}m / {node.available.cpu}m)
+            </h3>
           </div>
         </Col>
         <Col span={8}>
@@ -449,11 +451,14 @@ const NodeDetails = () => {
               percent={resources.memory * 100}
               strokeColor={gaugeColors}
             />
-            <h1>
+            <h1 style={{ marginBottom: "6px" }}>
               <strong>Memory</strong>
-              <br />({formatBytes(node.requested.memory)} /{" "}
-              {formatBytes(node.available.memory)})
             </h1>
+            <h3>
+              ({formatBytes(node.requested.memory)}
+              {" / "}
+              {formatBytes(node.available.memory)})
+            </h3>
           </div>
         </Col>
         <Col span={8}>
@@ -465,10 +470,12 @@ const NodeDetails = () => {
               percent={resources.pod_count * 100}
               strokeColor={gaugeColors}
             />
-            <h1>
+            <h1 style={{ marginBottom: "6px" }}>
               <strong>Pods</strong>
-              <br />({node.requested.pod_count} / {node.available.pod_count})
             </h1>
+            <h3>
+              ({node.requested.pod_count} / {node.available.pod_count})
+            </h3>
           </div>
         </Col>
       </Row>

--- a/cyclops-ui/src/components/pages/NodeDetails.tsx
+++ b/cyclops-ui/src/components/pages/NodeDetails.tsx
@@ -398,7 +398,7 @@ const NodeDetails = () => {
       </Row>
       <Row>
         <Text keyboard>
-          Created on:-{" "}
+          Created on: {" "}
           {new Date(
             node.node?.metadata?.creationTimestamp.toString(),
           ).toLocaleString()}

--- a/cyclops-ui/src/components/pages/NodeDetails.tsx
+++ b/cyclops-ui/src/components/pages/NodeDetails.tsx
@@ -11,7 +11,7 @@ import {
   Space,
   Table,
   Typography,
-  Progress
+  Progress,
 } from "antd";
 import "ace-builds/src-noconflict/ace";
 import { useParams } from "react-router-dom";
@@ -44,7 +44,7 @@ const NodeDetails = () => {
     pods: [],
     node: {
       metadata: {
-        creationTimestamp: new Date().toISOString()
+        creationTimestamp: new Date().toISOString(),
       },
       status: {
         conditions: [],
@@ -277,10 +277,7 @@ const NodeDetails = () => {
   useEffect(() => {
     const fetchNodeData = () => {
       axios
-        .get(
-          `https://stunning-space-computing-machine-wxxpjrpr4v5fgqv6-3000.app.github.dev/api/nodes/` +
-          nodeName,
-        )
+        .get(`/api/nodes/` + nodeName)
         .then((res) => {
           setNode(res.data);
           setResources({
@@ -370,6 +367,9 @@ const NodeDetails = () => {
     return gaugeColors["50%"];
   };
 
+  /**
+   * Color pallete for statuses of resources
+   */
   const gaugeColors = {
     "0%": "#57F287",
     "50%": "#FEE75C",
@@ -397,7 +397,12 @@ const NodeDetails = () => {
         <Title>{nodeName}</Title>
       </Row>
       <Row>
-        <Text keyboard>Created On:- {new Date(node.node?.metadata?.creationTimestamp.toString()).toLocaleString()}</Text>
+        <Text keyboard>
+          Created On:-{" "}
+          {new Date(
+            node.node?.metadata?.creationTimestamp.toString(),
+          ).toLocaleString()}
+        </Text>
       </Row>
       <Row>
         <Divider

--- a/cyclops-ui/src/components/pages/NodeDetails.tsx
+++ b/cyclops-ui/src/components/pages/NodeDetails.tsx
@@ -11,7 +11,7 @@ import {
   Space,
   Table,
   Typography,
-  Progress,
+  Progress
 } from "antd";
 import "ace-builds/src-noconflict/ace";
 import { useParams } from "react-router-dom";
@@ -25,7 +25,7 @@ import { SearchOutlined } from "@ant-design/icons";
 import Highlighter from "react-highlight-words";
 import { mapResponseError } from "../../utils/api/errors";
 
-const { Title } = Typography;
+const { Title, Text } = Typography;
 
 interface DataSourceType {
   name: string;
@@ -43,6 +43,9 @@ const NodeDetails = () => {
     name: String,
     pods: [],
     node: {
+      metadata: {
+        creationTimestamp: new Date().toISOString()
+      },
       status: {
         conditions: [],
       },
@@ -276,7 +279,7 @@ const NodeDetails = () => {
       axios
         .get(
           `https://stunning-space-computing-machine-wxxpjrpr4v5fgqv6-3000.app.github.dev/api/nodes/` +
-            nodeName,
+          nodeName,
         )
         .then((res) => {
           setNode(res.data);
@@ -392,6 +395,9 @@ const NodeDetails = () => {
       )}
       <Row>
         <Title>{nodeName}</Title>
+      </Row>
+      <Row>
+        <Text keyboard>Created On:- {new Date(node.node?.metadata?.creationTimestamp.toString()).toLocaleString()}</Text>
       </Row>
       <Row>
         <Divider


### PR DESCRIPTION
closes #422 
related to #440

## 📑 Description
Formatted Nodedetails page
added new ant design gauges
removed old react gauge & its pkg
better condition cards ui with icons
added node creation timestamp

## ✅ Checks
- [x] I have updated the documentation as required
- [x] I have performed a self-review of my code

## ℹ Additional context

![image](https://github.com/user-attachments/assets/80ccfaa4-ce78-4294-97e0-bc6a99a3075a)

color pallete preview :-
![image](https://github.com/user-attachments/assets/6befc979-03b0-4e4e-bcd3-351fde88846c)
