### PR TITLE
use the latest version for the OCI template default version

### DIFF
--- a/cyclops-ctrl/internal/template/semver.go
+++ b/cyclops-ctrl/internal/template/semver.go
@@ -14,6 +14,10 @@ func isValidVersion(v string) bool {
 }
 
 func resolveSemver(targetVersion string, versions []string) (string, error) {
+	// if targetVersion is empty, set it to a constraint that matches any version.
+	if targetVersion == "" {
+		targetVersion = "> 0.0.0"
+	}
 	contstraints, err := semver.NewConstraint(targetVersion)
 	if err != nil {
 		return "", nil


### PR DESCRIPTION
closes #

## 📑 Description

If the targetVersion is empty, the resolveSemver sets it to the constraint "> 0.0.0".

This ensures that any non-empty version will match, allowing the function to return the highest available version.

## ✅ Checks
- [ ] I have updated the documentation as required
- [x] I have performed a self-review of my code

## ℹ Additional context
