### PR TITLE
infer prop type

### DIFF
--- a/cyclops-ctrl/internal/mapper/helm.go
+++ b/cyclops-ctrl/internal/mapper/helm.go
@@ -143,6 +143,14 @@ func mapHelmPropertyTypeToFieldType(property helm.Property) string {
 
 		return "object"
 	default:
+		if len(property.Properties) > 0 {
+			return "object"
+		}
+
+		if property.Items != nil {
+			return "array"
+		}
+
 		return string(property.Type)
 	}
 }

--- a/cyclops-ctrl/internal/mapper/helm_test.go
+++ b/cyclops-ctrl/internal/mapper/helm_test.go
@@ -91,7 +91,21 @@ var _ = Describe("Helm mapper test", func() {
 					Type:       "what",
 					Properties: map[string]helm.Property{"nested": {Type: "string"}},
 				},
-				out: "what",
+				out: "object",
+			},
+			{
+				in: helm.Property{
+					Type:       "",
+					Properties: map[string]helm.Property{"nested": {Type: "string"}},
+				},
+				out: "object",
+			},
+			{
+				in: helm.Property{
+					Type:  "",
+					Items: &helm.Property{Type: "string"},
+				},
+				out: "array",
 			},
 		}
 


### PR DESCRIPTION
Infer type of fields in the schema:
- if `type` is not defined and `properties` are defined, infer type `object`
- if `type` is not defined and `items` are defined, infer type `array`