### PR TITLE
fix(cyclops-ui): path link on module card fixed

### DIFF
--- a/cyclops-ui/src/components/pages/Modules/Modules.tsx
+++ b/cyclops-ui/src/components/pages/Modules/Modules.tsx
@@ -84,6 +84,16 @@ const Modules = () => {
     return version + " - " + resolvedVersion.substring(0, 7);
   };
 
+  const getLinkPath = (version: string, resolvedVersion: string) => {
+    if (resolvedVersion !== "") {
+      return resolvedVersion;
+    }
+    if(version !== ""){
+      return version;
+    }
+    return "main";
+  };
+
   const renderModulesCards = () => {
     if (loadingModules) {
       return <Spin size={"large"} />;
@@ -133,7 +143,10 @@ const Modules = () => {
                 }}
               >
                 Repo:
-                <Link aria-level={3} href={module.template.repo}>
+                <Link aria-level={3}
+                 href={module.template.repo}
+                 target="_blank"
+                 >
                   {" " + module.template.repo}
                 </Link>
               </Col>
@@ -151,10 +164,11 @@ const Modules = () => {
                 Path:
                 <Link
                   aria-level={3}
+                  target="_blank"
                   href={
                     module.template.repo +
                     `/tree/` +
-                    getTemplateVersion(
+                    getLinkPath(
                       module.template.version,
                       module.template.resolvedVersion,
                     ) +


### PR DESCRIPTION
closes #336

## 📑 Description

## ✅ Checks
- [ ] I have updated the documentation as required
- [x] I have performed a self-review of my code

## ℹ Additional context

This PR fixes incorrect path url on the module card.
Path URL will contain resolvedVersion if it is not empty else it uses version and if both are not null then _main_ 
