### PR TITLE
🚀 feat: added cache metrics to the prometheus monitor

### DIFF
--- a/cyclops-ctrl/cmd/main/main.go
+++ b/cyclops-ctrl/cmd/main/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	_ "github.com/joho/godotenv/autoload"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,6 +80,8 @@ func main() {
 	}
 
 	renderer := render.NewRenderer(k8sClient)
+
+	prometheus.StartCacheMetricsUpdater(&monitor, templatesRepo.ReturnCache(), 10*time.Second, setupLog)
 
 	handler, err := handler.New(templatesRepo, k8sClient, renderer, telemetryClient, monitor)
 	if err != nil {

--- a/cyclops-ctrl/internal/prometheus/handler.go
+++ b/cyclops-ctrl/internal/prometheus/handler.go
@@ -1,26 +1,80 @@
 package prometheus
 
 import (
+	"time"
+
+	"github.com/dgraph-io/ristretto"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 type Monitor struct {
-	ModulesDeployed prometheus.Gauge
+	ModulesDeployed  prometheus.Gauge
+	CacheHits        prometheus.Counter
+	CacheMisses      prometheus.Counter
+	CacheKeysAdded   prometheus.Counter
+	CacheCostAdded   prometheus.Counter
+	CacheKeysEvicted prometheus.Counter
+	CacheCostEvicted prometheus.Counter
 }
 
 func NewMonitor(logger logr.Logger) (Monitor, error) {
+
 	m := Monitor{
 		ModulesDeployed: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name:      "modules_deployed",
 			Help:      "No of modules Inc or Dec",
 			Namespace: "cyclops",
 		}),
+		CacheHits: prometheus.NewCounter(prometheus.CounterOpts{
+			Name:      "cache_hits",
+			Help:      "No of cache hits",
+			Namespace: "cyclops",
+		}),
+		CacheMisses: prometheus.NewCounter(prometheus.CounterOpts{
+			Name:      "cache_misses",
+			Help:      "No of cache misses",
+			Namespace: "cyclops",
+		}),
+		CacheKeysAdded: prometheus.NewCounter(prometheus.CounterOpts{
+			Name:      "cache_keys_added",
+			Help:      "No of cache keys added",
+			Namespace: "cyclops",
+		}),
+		CacheCostAdded: prometheus.NewCounter(prometheus.CounterOpts{
+			Name:      "cache_cost_added",
+			Help:      "No of cache cost added",
+			Namespace: "cyclops",
+		}),
+		CacheKeysEvicted: prometheus.NewCounter(prometheus.CounterOpts{
+			Name:      "cache_keys_evicted",
+			Help:      "No of cache keys evicted",
+			Namespace: "cyclops",
+		}),
+		CacheCostEvicted: prometheus.NewCounter(prometheus.CounterOpts{
+			Name:      "cache_cost_evicted",
+			Help:      "No of cache cost evicted",
+			Namespace: "cyclops",
+		}),
 	}
-	if err := metrics.Registry.Register(m.ModulesDeployed); err != nil {
-		logger.Error(err, "unable to connect prometheus")
-		return Monitor{}, err
+
+	metricsList :=
+		[]prometheus.Collector{
+			m.ModulesDeployed,
+			m.CacheHits,
+			m.CacheMisses,
+			m.CacheKeysAdded,
+			m.CacheCostAdded,
+			m.CacheKeysEvicted,
+			m.CacheCostEvicted,
+		}
+
+	for _, metric := range metricsList {
+		if err := metrics.Registry.Register(metric); err != nil {
+			logger.Error(err, "unable to connect prometheus")
+			return Monitor{}, err
+		}
 	}
 
 	return m, nil
@@ -32,4 +86,28 @@ func (m *Monitor) IncModule() {
 
 func (m *Monitor) DecModule() {
 	m.ModulesDeployed.Dec()
+}
+
+func (m *Monitor) UpdateCacheMetrics(cache *ristretto.Cache) {
+	cacheMetrics := cache.Metrics
+
+	m.CacheHits.Add(float64(cacheMetrics.Hits()))
+	m.CacheMisses.Add(float64(cacheMetrics.Misses()))
+	m.CacheKeysAdded.Add(float64(cacheMetrics.KeysAdded()))
+	m.CacheCostAdded.Add(float64(cacheMetrics.CostAdded()))
+	m.CacheKeysEvicted.Add(float64(cacheMetrics.KeysEvicted()))
+	m.CacheCostEvicted.Add(float64(cacheMetrics.CostEvicted()))
+}
+
+func StartCacheMetricsUpdater(m *Monitor, cache *ristretto.Cache, interval time.Duration, logger logr.Logger) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		logger.Info("starting cache metrics updater")
+
+		for range ticker.C {
+			m.UpdateCacheMetrics(cache)
+		}
+	}()
 }

--- a/cyclops-ctrl/internal/prometheus/handler.go
+++ b/cyclops-ctrl/internal/prometheus/handler.go
@@ -11,12 +11,12 @@ import (
 
 type Monitor struct {
 	ModulesDeployed  prometheus.Gauge
-	CacheHits        prometheus.Counter
-	CacheMisses      prometheus.Counter
-	CacheKeysAdded   prometheus.Counter
-	CacheCostAdded   prometheus.Counter
-	CacheKeysEvicted prometheus.Counter
-	CacheCostEvicted prometheus.Counter
+	CacheHits        prometheus.Gauge
+	CacheMisses      prometheus.Gauge
+	CacheKeysAdded   prometheus.Gauge
+	CacheCostAdded   prometheus.Gauge
+	CacheKeysEvicted prometheus.Gauge
+	CacheCostEvicted prometheus.Gauge
 }
 
 func NewMonitor(logger logr.Logger) (Monitor, error) {
@@ -27,32 +27,32 @@ func NewMonitor(logger logr.Logger) (Monitor, error) {
 			Help:      "No of modules Inc or Dec",
 			Namespace: "cyclops",
 		}),
-		CacheHits: prometheus.NewCounter(prometheus.CounterOpts{
+		CacheHits: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name:      "cache_hits",
 			Help:      "No of cache hits",
 			Namespace: "cyclops",
 		}),
-		CacheMisses: prometheus.NewCounter(prometheus.CounterOpts{
+		CacheMisses: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name:      "cache_misses",
 			Help:      "No of cache misses",
 			Namespace: "cyclops",
 		}),
-		CacheKeysAdded: prometheus.NewCounter(prometheus.CounterOpts{
+		CacheKeysAdded: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name:      "cache_keys_added",
 			Help:      "No of cache keys added",
 			Namespace: "cyclops",
 		}),
-		CacheCostAdded: prometheus.NewCounter(prometheus.CounterOpts{
+		CacheCostAdded: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name:      "cache_cost_added",
 			Help:      "No of cache cost added",
 			Namespace: "cyclops",
 		}),
-		CacheKeysEvicted: prometheus.NewCounter(prometheus.CounterOpts{
+		CacheKeysEvicted: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name:      "cache_keys_evicted",
 			Help:      "No of cache keys evicted",
 			Namespace: "cyclops",
 		}),
-		CacheCostEvicted: prometheus.NewCounter(prometheus.CounterOpts{
+		CacheCostEvicted: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name:      "cache_cost_evicted",
 			Help:      "No of cache cost evicted",
 			Namespace: "cyclops",
@@ -91,12 +91,12 @@ func (m *Monitor) DecModule() {
 func (m *Monitor) UpdateCacheMetrics(cache *ristretto.Cache) {
 	cacheMetrics := cache.Metrics
 
-	m.CacheHits.Add(float64(cacheMetrics.Hits()))
-	m.CacheMisses.Add(float64(cacheMetrics.Misses()))
-	m.CacheKeysAdded.Add(float64(cacheMetrics.KeysAdded()))
-	m.CacheCostAdded.Add(float64(cacheMetrics.CostAdded()))
-	m.CacheKeysEvicted.Add(float64(cacheMetrics.KeysEvicted()))
-	m.CacheCostEvicted.Add(float64(cacheMetrics.CostEvicted()))
+	m.CacheHits.Set(float64(cacheMetrics.Hits()))
+	m.CacheMisses.Set(float64(cacheMetrics.Misses()))
+	m.CacheKeysAdded.Set(float64(cacheMetrics.KeysAdded()))
+	m.CacheCostAdded.Set(float64(cacheMetrics.CostAdded()))
+	m.CacheKeysEvicted.Set(float64(cacheMetrics.KeysEvicted()))
+	m.CacheCostEvicted.Set(float64(cacheMetrics.CostEvicted()))
 }
 
 func StartCacheMetricsUpdater(m *Monitor, cache *ristretto.Cache, interval time.Duration, logger logr.Logger) {

--- a/cyclops-ctrl/internal/template/cache/inmemory.go
+++ b/cyclops-ctrl/internal/template/cache/inmemory.go
@@ -19,6 +19,7 @@ func NewInMemoryTemplatesCache() Templates {
 		NumCounters: 1e7,     // number of keys to track frequency of (10M).
 		MaxCost:     1 << 30, // maximum cost of cache (1GB).
 		BufferItems: 64,      // number of keys per Get buffer.
+		Metrics:     true,
 	})
 	if err != nil {
 		panic(err)
@@ -80,6 +81,10 @@ func (t Templates) SetTemplateInitialValues(repo, path, version string, values m
 
 	t.cache.SetWithTTL(initialValuesKey(repo, path, version), values, int64(len(data)), time.Minute*15)
 	t.cache.Wait()
+}
+
+func (t Templates) ReturnCache() *ristretto.Cache {
+	return t.cache
 }
 
 func templateKey(repo, path, version string) string {

--- a/cyclops-ctrl/internal/template/template.go
+++ b/cyclops-ctrl/internal/template/template.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cyclops-ui/cyclops/cyclops-ctrl/internal/auth"
 	"github.com/cyclops-ui/cyclops/cyclops-ctrl/internal/models"
 	"github.com/cyclops-ui/cyclops/cyclops-ctrl/internal/models/helm"
+	"github.com/dgraph-io/ristretto"
 )
 
 type Repo struct {
@@ -18,6 +19,7 @@ type templateCache interface {
 	SetTemplate(repo, path, version string, template *models.Template)
 	GetTemplateInitialValues(repo, path, version string) (map[string]interface{}, bool)
 	SetTemplateInitialValues(repo, path, version string, values map[string]interface{})
+	ReturnCache() *ristretto.Cache
 }
 
 func NewRepo(credResolver auth.TemplatesResolver, tc templateCache) *Repo {
@@ -105,4 +107,8 @@ func (r Repo) loadDependenciesInitialValues(metadata *helm.Metadata) (map[string
 	}
 
 	return initialValues, nil
+}
+
+func (r Repo) ReturnCache() *ristretto.Cache {
+	return r.cache.ReturnCache()
 }


### PR DESCRIPTION
closes #469

## 📑 Description
- added cache metrics to the Prometheus monitor
- currently added metrics are 
```go
 type Monitor struct {
	ModulesDeployed  prometheus.Gauge
	CacheHits        prometheus.Counter
	CacheMisses      prometheus.Counter
	CacheKeysAdded   prometheus.Counter
	CacheCostAdded   prometheus.Counter
	CacheKeysEvicted prometheus.Counter
	CacheCostEvicted prometheus.Counter
}
```
- added methods to update the cache metrics
- added cronjob which run every 10 seconds to update the cache metrics

## ✅ Checks
- [ ] I have updated the documentation as required
- [✅] I have performed a self-review of my code

## ℹ Additional context
- More metrics for the cache can be added if and when required
- Current time delta of 10 seconds to update the cache metrics is chosen randomly
