### PR TITLE
feat: Add loading state for template in EditModule and NewModule components

### DIFF
--- a/cyclops-ui/src/components/pages/EditModule/EditModule.tsx
+++ b/cyclops-ui/src/components/pages/EditModule/EditModule.tsx
@@ -90,6 +90,7 @@ const EditModule = () => {
   const [values, setValues] = useState({});
   const [isChanged, setIsChanged] = useState(false);
   const [isTemplateChanged, setIsTemplateChanged] = useState(false);
+  const [isTemplateLoading, setIsTemplateLoading] = useState(false);
   const [config, setConfig] = useState<Template>({
     name: "",
     resolvedVersion: "",
@@ -308,6 +309,7 @@ const EditModule = () => {
   };
 
   async function handleSubmitTemplateEdit(templateEditValues: any) {
+    setIsTemplateLoading(true);
     setLoadTemplate(false);
 
     let currentValues = form.getFieldsValue();
@@ -378,6 +380,7 @@ const EditModule = () => {
     setInitialValuesRaw(initialValuesResult.initialValues);
     form.setFieldsValue(mergedValuesMapped);
 
+    setIsTemplateLoading(false);
     setLoadTemplate(true);
   }
 
@@ -1077,7 +1080,7 @@ const EditModule = () => {
   }
 
   const formLoading = () => {
-    if (loadTemplate === false || loadValues === false) {
+    if (loadTemplate === false || loadValues === false || isTemplateLoading) {
       return (
         <Spin tip="Loading" size="large" style={{ alignContent: "center" }} />
       );
@@ -1099,13 +1102,14 @@ const EditModule = () => {
             type="primary"
             htmlType="submit"
             name="Save"
-            disabled={!isChanged && !isTemplateChanged}
+            disabled={(!isChanged && !isTemplateChanged) || isTemplateLoading}
           >
             Save
           </Button>{" "}
           <Button
             htmlType="button"
             onClick={() => history("/modules/" + moduleName)}
+            disabled={isTemplateLoading}
           >
             Back
           </Button>
@@ -1227,7 +1231,10 @@ const EditModule = () => {
                 name={"repo"}
                 style={{ width: "40%", marginRight: "0" }}
               >
-                <Input placeholder={"Repository"} disabled={templateRefLock} />
+                <Input
+                  placeholder={"Repository"}
+                  disabled={templateRefLock || isTemplateLoading}
+                />
               </Form.Item>
               <div
                 style={{
@@ -1262,7 +1269,7 @@ const EditModule = () => {
                 <Input
                   placeholder={"Version"}
                   addonAfter={linkToTemplate(templateRef)}
-                  disabled={templateRefLock}
+                  disabled={templateRefLock || isTemplateLoading}
                 />
               </Form.Item>
               <Form.Item style={{ paddingLeft: "10px", width: "5%" }}>
@@ -1270,7 +1277,7 @@ const EditModule = () => {
                   type="primary"
                   htmlType="submit"
                   loading={!loadTemplate}
-                  disabled={templateRefLock}
+                  disabled={templateRefLock || isTemplateLoading}
                 >
                   Load
                 </Button>

--- a/cyclops-ui/src/components/pages/EditModule/EditModule.tsx
+++ b/cyclops-ui/src/components/pages/EditModule/EditModule.tsx
@@ -1247,7 +1247,10 @@ const EditModule = () => {
                 name={"path"}
                 style={{ width: "20%", marginRight: "0" }}
               >
-                <Input placeholder={"Path"} disabled={templateRefLock} />
+                <Input
+                  placeholder={"Path"}
+                  disabled={templateRefLock || !loadTemplate}
+                />
               </Form.Item>
               <div
                 style={{

--- a/cyclops-ui/src/components/pages/EditModule/EditModule.tsx
+++ b/cyclops-ui/src/components/pages/EditModule/EditModule.tsx
@@ -90,7 +90,6 @@ const EditModule = () => {
   const [values, setValues] = useState({});
   const [isChanged, setIsChanged] = useState(false);
   const [isTemplateChanged, setIsTemplateChanged] = useState(false);
-  const [isTemplateLoading, setIsTemplateLoading] = useState(false);
   const [config, setConfig] = useState<Template>({
     name: "",
     resolvedVersion: "",
@@ -309,7 +308,6 @@ const EditModule = () => {
   };
 
   async function handleSubmitTemplateEdit(templateEditValues: any) {
-    setIsTemplateLoading(true);
     setLoadTemplate(false);
 
     let currentValues = form.getFieldsValue();
@@ -380,7 +378,6 @@ const EditModule = () => {
     setInitialValuesRaw(initialValuesResult.initialValues);
     form.setFieldsValue(mergedValuesMapped);
 
-    setIsTemplateLoading(false);
     setLoadTemplate(true);
   }
 
@@ -1080,7 +1077,7 @@ const EditModule = () => {
   }
 
   const formLoading = () => {
-    if (loadTemplate === false || loadValues === false || isTemplateLoading) {
+    if (loadTemplate === false || loadValues === false) {
       return (
         <Spin tip="Loading" size="large" style={{ alignContent: "center" }} />
       );
@@ -1102,14 +1099,14 @@ const EditModule = () => {
             type="primary"
             htmlType="submit"
             name="Save"
-            disabled={(!isChanged && !isTemplateChanged) || isTemplateLoading}
+            disabled={(!isChanged && !isTemplateChanged) || !loadTemplate}
           >
             Save
           </Button>{" "}
           <Button
             htmlType="button"
             onClick={() => history("/modules/" + moduleName)}
-            disabled={isTemplateLoading}
+            disabled={!loadTemplate}
           >
             Back
           </Button>
@@ -1233,7 +1230,7 @@ const EditModule = () => {
               >
                 <Input
                   placeholder={"Repository"}
-                  disabled={templateRefLock || isTemplateLoading}
+                  disabled={templateRefLock || !loadTemplate}
                 />
               </Form.Item>
               <div
@@ -1269,7 +1266,7 @@ const EditModule = () => {
                 <Input
                   placeholder={"Version"}
                   addonAfter={linkToTemplate(templateRef)}
-                  disabled={templateRefLock || isTemplateLoading}
+                  disabled={templateRefLock || !loadTemplate}
                 />
               </Form.Item>
               <Form.Item style={{ paddingLeft: "10px", width: "5%" }}>
@@ -1277,7 +1274,7 @@ const EditModule = () => {
                   type="primary"
                   htmlType="submit"
                   loading={!loadTemplate}
-                  disabled={templateRefLock || isTemplateLoading}
+                  disabled={templateRefLock || !loadTemplate}
                 >
                   Load
                 </Button>

--- a/cyclops-ui/src/components/pages/NewModule/NewModule.tsx
+++ b/cyclops-ui/src/components/pages/NewModule/NewModule.tsx
@@ -1206,7 +1206,7 @@ const NewModule = () => {
                   onChange={onTemplateStoreSelected}
                   style={{ width: "100%" }}
                   placeholder="Select an option"
-                  disabled={loadingTemplate}
+                  disabled={loadingTemplate || loadingTemplateInitialValues}
                 >
                   {templateStore.map((option: any, index) => (
                     <Option key={option.name} value={option.name}>
@@ -1284,13 +1284,15 @@ const NewModule = () => {
                   setLoadingValuesModal(true);
                 }}
                 name="Save"
-                disabled={loadingTemplate}
+                disabled={loadingTemplate || loadingTemplateInitialValues}
               >
                 Load values from file
               </Button>{" "}
               <Button
                 type="primary"
-                loading={loading || loadingTemplate}
+                loading={
+                  loading || loadingTemplate || loadingTemplateInitialValues
+                }
                 htmlType="submit"
                 name="Save"
                 disabled={loadingTemplate}
@@ -1300,7 +1302,7 @@ const NewModule = () => {
               <Button
                 htmlType="button"
                 onClick={() => history("/")}
-                disabled={loadingTemplate}
+                disabled={loadingTemplate || loadingTemplateInitialValues}
               >
                 Back
               </Button>

--- a/cyclops-ui/src/components/pages/NewModule/NewModule.tsx
+++ b/cyclops-ui/src/components/pages/NewModule/NewModule.tsx
@@ -1295,7 +1295,7 @@ const NewModule = () => {
                 }
                 htmlType="submit"
                 name="Save"
-                disabled={loadingTemplate}
+                disabled={loadingTemplate || loadingTemplateInitialValues}
               >
                 Save
               </Button>{" "}

--- a/cyclops-ui/src/components/pages/NewModule/NewModule.tsx
+++ b/cyclops-ui/src/components/pages/NewModule/NewModule.tsx
@@ -1206,6 +1206,7 @@ const NewModule = () => {
                   onChange={onTemplateStoreSelected}
                   style={{ width: "100%" }}
                   placeholder="Select an option"
+                  disabled={loadingTemplate}
                 >
                   {templateStore.map((option: any, index) => (
                     <Option key={option.name} value={option.name}>
@@ -1283,18 +1284,24 @@ const NewModule = () => {
                   setLoadingValuesModal(true);
                 }}
                 name="Save"
+                disabled={loadingTemplate}
               >
                 Load values from file
               </Button>{" "}
               <Button
                 type="primary"
-                loading={loading}
+                loading={loading || loadingTemplate}
                 htmlType="submit"
                 name="Save"
+                disabled={loadingTemplate}
               >
                 Save
               </Button>{" "}
-              <Button htmlType="button" onClick={() => history("/")}>
+              <Button
+                htmlType="button"
+                onClick={() => history("/")}
+                disabled={loadingTemplate}
+              >
                 Back
               </Button>
             </div>


### PR DESCRIPTION
closes #423 

## 📑 Description

Disables the `save` and `load values from file` buttons when a template is loading. also, it Disables changing of template when a template is loading.

## ✅ Checks
- [x] I have updated the documentation as required
- [x] I have performed a self-review of my code