### PR TITLE
implement networkpolicy data api for controller

### DIFF
--- a/cyclops-ctrl/internal/cluster/k8sclient/modules.go
+++ b/cyclops-ctrl/internal/cluster/k8sclient/modules.go
@@ -10,6 +10,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	apiv1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -670,6 +671,53 @@ func (k *KubernetesClient) getPodsForJob(job batchv1.Job) ([]dto.Pod, error) {
 
 	return out, nil
 
+}
+
+func (k *KubernetesClient) getPodsForNetworkPolicy(policy networkingv1.NetworkPolicy) ([]dto.Pod, error) {
+	pods, err := k.clientset.CoreV1().Pods(policy.Namespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: labels.Set(policy.Spec.PodSelector.MatchLabels).String(),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]dto.Pod, 0, len(pods.Items))
+	for _, item := range pods.Items {
+		containers := make([]dto.Container, 0, len(item.Spec.Containers))
+
+		for _, cnt := range item.Spec.Containers {
+			env := make(map[string]string)
+			for _, envVar := range cnt.Env {
+				env[envVar.Name] = envVar.Value
+			}
+
+			var status apiv1.ContainerStatus
+			for _, c := range item.Status.ContainerStatuses {
+				if c.Name == cnt.Name {
+					status = c
+					break
+				}
+			}
+
+			containers = append(containers, dto.Container{
+				Name:   cnt.Name,
+				Image:  cnt.Image,
+				Env:    env,
+				Status: containerStatus(status),
+			})
+		}
+
+		out = append(out, dto.Pod{
+			Name:       item.Name,
+			Containers: containers,
+			Node:       item.Spec.NodeName,
+			PodPhase:   string(item.Status.Phase),
+			Started:    item.Status.StartTime,
+		})
+	}
+
+	return out, nil
 }
 
 func containerStatus(status apiv1.ContainerStatus) dto.ContainerStatus {

--- a/cyclops-ctrl/internal/models/dto/k8s.go
+++ b/cyclops-ctrl/internal/models/dto/k8s.go
@@ -4,6 +4,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type Resource interface {
@@ -554,6 +555,74 @@ func (c *Job) GetCompletionTime() string {
 
 func (c *Job) GetStartTime() string {
 	return c.StartTime
+}
+
+type NetworkPolicy struct {
+	Group     string                     `json:"group"`
+	Version   string                     `json:"version"`
+	Kind      string                     `json:"kind"`
+	Name      string                     `json:"name"`
+	Namespace string                     `json:"namespace"`
+	Pods      []Pod                      `json:"pods"`
+	Ingress   []NetworkPolicyIngressRule `json:"ingress"`
+	Egress    []NetworkPolicyEgressRule  `json:"egress"`
+}
+
+func (n *NetworkPolicy) GetGroupVersionKind() string {
+	return n.Group + "/" + n.Version + ", Kind=" + n.Kind
+}
+
+func (n *NetworkPolicy) GetGroup() string {
+	return n.Group
+}
+
+func (n *NetworkPolicy) GetVersion() string {
+	return n.Version
+}
+
+func (n *NetworkPolicy) GetKind() string {
+	return n.Kind
+}
+
+func (n *NetworkPolicy) GetName() string {
+	return n.Name
+}
+
+func (n *NetworkPolicy) GetNamespace() string {
+	return n.Namespace
+}
+
+func (n *NetworkPolicy) GetIngress() []NetworkPolicyIngressRule {
+	return n.Ingress
+}
+
+func (n *NetworkPolicy) GetEgress() []NetworkPolicyEgressRule {
+	return n.Egress
+}
+
+type NetworkPolicyIngressRule struct {
+	Ports []NetworkPolicyPort `json:"ports"`
+	From  []NetworkPolicyPeer `json:"from"`
+}
+
+type NetworkPolicyEgressRule struct {
+	Ports []NetworkPolicyPort `json:"ports,"`
+	To    []NetworkPolicyPeer `json:"to"`
+}
+
+type NetworkPolicyPort struct {
+	Protocol string             `json:"protocol"`
+	Port     intstr.IntOrString `json:"port"`
+	EndPort  int32              `json:"endPort"`
+}
+
+type NetworkPolicyPeer struct {
+	IPBlock *IPBlock `json:"ipBlock"`
+}
+
+type IPBlock struct {
+	CIDR   string   `json:"cidr"`
+	Except []string `json:"except"`
 }
 
 type Other struct {


### PR DESCRIPTION
closes #433 

## 📑 Description
- This PR implements fetching data for NetworkPolicy on the controller.
- Here is an example for the API call:
  - `/resources?group=networking.k8s.io&version=v1&kind=NetworkPolicy&name=test-network-policy&namespace=default`
- Here is an example for the API returns:
	```json
	{
	  "group": "networking",
	  "version": "v1",
	  "kind": "NetworkPolicy",
	  "name": "test-network-policy",
	  "namespace": "default",
	  "pods": [],
	  "ingress": [
	    {
	      "ports": [
	        {
	          "protocol": "TCP",
	          "port": 6379,
	          "endPort": 0
	        }
	      ],
	      "from": [
	        {
	          "ipBlock": {
	            "cidr": "172.17.0.0/16",
	            "except": [
	              "172.17.1.0/24"
	            ]
	          }
	        },
	        {
	          "ipBlock": null
	        },
	        {
	          "ipBlock": null
	        }
	      ]
	    }
	  ],
	  "egress": [
	    {
	      "ports": [
	        {
	          "protocol": "TCP",
	          "port": 5978,
	          "endPort": 0
	        }
	      ],
	      "to": [
	        {
	          "ipBlock": {
	            "cidr": "10.0.0.0/24",
	            "except": null
	          }
	        }
	      ]
	    }
	  ]
	}
	
	```


## ✅ Checks
- [ ] I have updated the documentation as required
- [x] I have performed a self-review of my code

## ℹ Additional context
