### PR TITLE
Disabling save button if no template is selected

### DIFF
--- a/cyclops-ui/src/components/pages/NewModule/NewModule.tsx
+++ b/cyclops-ui/src/components/pages/NewModule/NewModule.tsx
@@ -1298,7 +1298,7 @@ const NewModule = () => {
                 disabled={
                   loadingTemplate ||
                   loadingTemplateInitialValues ||
-                  !template.version
+                  !(template.version || template.path || template.repo)
                 }
               >
                 Save

--- a/cyclops-ui/src/components/pages/NewModule/NewModule.tsx
+++ b/cyclops-ui/src/components/pages/NewModule/NewModule.tsx
@@ -1295,7 +1295,11 @@ const NewModule = () => {
                 }
                 htmlType="submit"
                 name="Save"
-                disabled={loadingTemplate || loadingTemplateInitialValues}
+                disabled={
+                  loadingTemplate ||
+                  loadingTemplateInitialValues ||
+                  !template.version
+                }
               >
                 Save
               </Button>{" "}


### PR DESCRIPTION
closes #503 

## 📑 Description
- Disabling save button in create new module until a template is selected

## ✅ Checks
- [ ] I have updated the documentation as required
- [x] I have performed a self-review of my code

## ℹ Additional context
