### PR TITLE
504 - Copy manifest button

### DIFF
--- a/cyclops-ui/src/components/pages/ModuleDetails.tsx
+++ b/cyclops-ui/src/components/pages/ModuleDetails.tsx
@@ -22,6 +22,7 @@ import {
   CaretRightOutlined,
   CheckCircleTwoTone,
   CloseSquareTwoTone,
+  CopyOutlined,
   SearchOutlined,
   WarningTwoTone,
 } from "@ant-design/icons";
@@ -958,31 +959,36 @@ const ModuleDetails = () => {
         cancelButtonProps={{ style: { display: "none" } }}
         width={"40%"}
       >
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-          }}
-        >
-          <Checkbox onChange={handleCheckboxChange} checked={showManagedFields}>
-            Include Managed Fields
-          </Checkbox>
-          <Button
-            onClick={() => {
-              navigator.clipboard.writeText(manifestModal.manifest);
-            }}
-          >
-            Copy Manifest
-          </Button>
-        </div>
+        <Checkbox onChange={handleCheckboxChange} checked={showManagedFields}>
+          Include Managed Fields
+        </Checkbox>
         <Divider style={{ marginTop: "12px", marginBottom: "12px" }} />
-        <ReactAce
-          style={{ width: "100%" }}
-          mode={"sass"}
-          value={manifestModal.manifest}
-          readOnly={true}
-        />
+        <div style={{ position: "relative" }}>
+          <ReactAce
+            style={{ width: "100%" }}
+            mode={"sass"}
+            value={manifestModal.manifest}
+            readOnly={true}
+          />
+          <Tooltip title={"Copy Manifest"} trigger="hover">
+            <Button
+              onClick={() => {
+                navigator.clipboard.writeText(manifestModal.manifest);
+              }}
+              style={{
+                position: "absolute",
+                right: "20px",
+                top: "10px",
+              }}
+            >
+              <CopyOutlined
+                style={{
+                  fontSize: "20px",
+                }}
+              />
+            </Button>
+          </Tooltip>
+        </div>
       </Modal>
       <Modal
         title={

--- a/cyclops-ui/src/components/pages/ModuleDetails.tsx
+++ b/cyclops-ui/src/components/pages/ModuleDetails.tsx
@@ -958,12 +958,25 @@ const ModuleDetails = () => {
         cancelButtonProps={{ style: { display: "none" } }}
         width={"40%"}
       >
-        <div>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
           <Checkbox onChange={handleCheckboxChange} checked={showManagedFields}>
             Include Managed Fields
           </Checkbox>
-          <Divider style={{ marginTop: "12px", marginBottom: "12px" }} />
+          <Button
+            onClick={() => {
+              navigator.clipboard.writeText(manifestModal.manifest);
+            }}
+          >
+            Copy Manifest
+          </Button>
         </div>
+        <Divider style={{ marginTop: "12px", marginBottom: "12px" }} />
         <ReactAce
           style={{ width: "100%" }}
           mode={"sass"}


### PR DESCRIPTION
closes #504 

## 📑 Description
Added a button in the top right corner of the editor, featuring a tooltip that allows users to easily copy the manifest script.

## ✅ Checks
- [x] I have updated the documentation as required
- [x] I have performed a self-review of my code

## ℹ Additional context
Position and styling of the button:
![Cyclops Copy Manifest](https://github.com/user-attachments/assets/b9518861-2a0e-4db1-8b72-165732630511)

