### PR TITLE
Support multiple values module update

### DIFF
--- a/cyctl/cmd/update.go
+++ b/cyctl/cmd/update.go
@@ -7,10 +7,10 @@ import (
 
 var (
 	updateExample = `# updates the given module 
-cyctl update module <module-name> --key=<key> --value=<value> 
+cyctl update module <module-name> --value="<key>=<value>" --value="<key>=<value>"
 
-# to update replicas for a module named test,updates number of replicas to 3
-cyctl update module <module-name> test --key="scaling.replicas" --value=3`
+# to update replicas and version for a module named test, with 3 replicas and version 1.27.1
+cyctl update module test --value="scaling.replicas=3" --value="general.version=1.27.1"`
 )
 
 var (

--- a/cyctl/internal/update/modules.go
+++ b/cyctl/internal/update/modules.go
@@ -14,9 +14,9 @@ import (
 )
 
 var (
-	updateModuleExample = `# updates module values; takes module name as an argument with flags --key and --value
-# to update replicas for a module named test 
-cyctl update module test --key="scaling.replicas" --value=3
+	updateModuleExample = `# updates module values; takes module name as an argument with flag --value
+# to update replicas and version for a module named test
+cyctl update module test --value="scaling.replicas=3" --value="general.version=1.27.1"
 	`
 )
 

--- a/cyctl/internal/update/modules.go
+++ b/cyctl/internal/update/modules.go
@@ -82,7 +82,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			values, err := cmd.Flags().GetStringArray("value")
 			if err != nil {
-				fmt.Println("failed to get value of flag --value ")
+				fmt.Println("failed to get value of flag --value: ", err)
 				return
 			}
 


### PR DESCRIPTION
closes #519 

## 📑 Description
Removed `key` flag and changed `value` flag to support multiple values.

## ✅ Checks
- [ ] I have updated the documentation as required
- [x] I have performed a self-review of my code

## ℹ Additional context
Used [StringArrayP](https://github.com/spf13/pflag/blob/v1.0.5/string_array.go#L127) [¶](https://pkg.go.dev/github.com/spf13/pflag?utm_source=godoc#StringArrayP) instead of [StringSliceP](https://github.com/spf13/pflag/blob/v1.0.5/string_slice.go#L161) [¶](https://pkg.go.dev/github.com/spf13/pflag?utm_source=godoc#StringSliceP), so `--ss="v1,v2" --ss="v3"` will not work.