### PR TITLE
🚀 feat: added delete pod functionality to the pod table

### DIFF
--- a/cyclops-ui/src/components/k8s-resources/CronJob.tsx
+++ b/cyclops-ui/src/components/k8s-resources/CronJob.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { Col, Divider, Row, Alert } from "antd";
 import axios from "axios";
 import { mapResponseError } from "../../utils/api/errors";
@@ -14,43 +14,38 @@ const CronJob = ({ name, namespace }: Props) => {
     status: "",
     pods: [],
   });
-  const [triggerReload, setTriggerReload] = useState<boolean>(false);
-
-  const handleTriggerReloadUpdate = () => {
-    setTriggerReload(!triggerReload);
-  };
 
   const [error, setError] = useState({
     message: "",
     description: "",
   });
 
-  useEffect(() => {
-    function fetchCronJob() {
-      axios
-        .get(`/api/resources`, {
-          params: {
-            group: `batch`,
-            version: `v1`,
-            kind: `CronJob`,
-            name: name,
-            namespace: namespace,
-          },
-        })
-        .then((res) => {
-          setCronjob(res.data);
-        })
-        .catch((error) => {
-          setError(mapResponseError(error));
-        });
-    }
+  const fetchCronJob = useCallback(() => {
+    axios
+      .get(`/api/resources`, {
+        params: {
+          group: `batch`,
+          version: `v1`,
+          kind: `CronJob`,
+          name: name,
+          namespace: namespace,
+        },
+      })
+      .then((res) => {
+        setCronjob(res.data);
+      })
+      .catch((error) => {
+        setError(mapResponseError(error));
+      });
+  }, [name, namespace]);
 
+  useEffect(() => {
     fetchCronJob();
     const interval = setInterval(() => fetchCronJob(), 15000);
     return () => {
       clearInterval(interval);
     };
-  }, [name, namespace, triggerReload]);
+  }, [fetchCronJob]);
 
   return (
     <div>
@@ -81,7 +76,7 @@ const CronJob = ({ name, namespace }: Props) => {
           <PodTable
             namespace={namespace}
             pods={cronjob.pods}
-            handleTriggerReloadUpdate={handleTriggerReloadUpdate}
+            updateResourceData={fetchCronJob}
           />
         </Col>
       </Row>

--- a/cyclops-ui/src/components/k8s-resources/CronJob.tsx
+++ b/cyclops-ui/src/components/k8s-resources/CronJob.tsx
@@ -14,6 +14,11 @@ const CronJob = ({ name, namespace }: Props) => {
     status: "",
     pods: [],
   });
+  const [triggerReload, setTriggerReload] = useState<boolean>(false);
+
+  const handleTriggerReloadUpdate = () => {
+    setTriggerReload(!triggerReload);
+  };
 
   const [error, setError] = useState({
     message: "",
@@ -45,7 +50,7 @@ const CronJob = ({ name, namespace }: Props) => {
     return () => {
       clearInterval(interval);
     };
-  }, [name, namespace]);
+  }, [name, namespace, triggerReload]);
 
   return (
     <div>
@@ -73,7 +78,11 @@ const CronJob = ({ name, namespace }: Props) => {
           Pods: {cronjob.pods.length}
         </Divider>
         <Col span={24} style={{ overflowX: "auto" }}>
-          <PodTable namespace={namespace} pods={cronjob.pods} />
+          <PodTable
+            namespace={namespace}
+            pods={cronjob.pods}
+            handleTriggerReloadUpdate={handleTriggerReloadUpdate}
+          />
         </Col>
       </Row>
     </div>

--- a/cyclops-ui/src/components/k8s-resources/DaemonSet.tsx
+++ b/cyclops-ui/src/components/k8s-resources/DaemonSet.tsx
@@ -14,6 +14,12 @@ const DaemonSet = ({ name, namespace }: Props) => {
     status: "",
     pods: [],
   });
+  const [triggerReload, setTriggerReload] = useState<boolean>(false);
+
+  const handleTriggerReloadUpdate = () => {
+    setTriggerReload(!triggerReload);
+  };
+
   const [error, setError] = useState({
     message: "",
     description: "",
@@ -44,7 +50,7 @@ const DaemonSet = ({ name, namespace }: Props) => {
     return () => {
       clearInterval(interval);
     };
-  }, [name, namespace]);
+  }, [name, namespace, triggerReload]);
 
   return (
     <div>
@@ -72,7 +78,11 @@ const DaemonSet = ({ name, namespace }: Props) => {
           Pods: {daemonSet.pods.length}
         </Divider>
         <Col span={24} style={{ overflowX: "auto" }}>
-          <PodTable namespace={namespace} pods={daemonSet.pods} />
+          <PodTable
+            namespace={namespace}
+            pods={daemonSet.pods}
+            handleTriggerReloadUpdate={handleTriggerReloadUpdate}
+          />
         </Col>
       </Row>
     </div>

--- a/cyclops-ui/src/components/k8s-resources/Deployment.tsx
+++ b/cyclops-ui/src/components/k8s-resources/Deployment.tsx
@@ -18,6 +18,11 @@ const Deployment = ({ name, namespace }: Props) => {
     message: "",
     description: "",
   });
+  const [triggerReload, setTriggerReload] = useState<boolean>(false);
+
+  const handleTriggerReloadUpdate = () => {
+    setTriggerReload(!triggerReload);
+  };
 
   useEffect(() => {
     function fetchDeployment() {
@@ -44,7 +49,7 @@ const Deployment = ({ name, namespace }: Props) => {
     return () => {
       clearInterval(interval);
     };
-  }, [name, namespace]);
+  }, [name, namespace, triggerReload]);
 
   return (
     <div>
@@ -72,7 +77,11 @@ const Deployment = ({ name, namespace }: Props) => {
           Replicas: {deployment.pods.length}
         </Divider>
         <Col span={24} style={{ overflowX: "auto" }}>
-          <PodTable namespace={namespace} pods={deployment.pods} />
+          <PodTable
+            namespace={namespace}
+            pods={deployment.pods}
+            handleTriggerReloadUpdate={handleTriggerReloadUpdate}
+          />
         </Col>
       </Row>
     </div>

--- a/cyclops-ui/src/components/k8s-resources/Job.tsx
+++ b/cyclops-ui/src/components/k8s-resources/Job.tsx
@@ -14,6 +14,11 @@ const Job = ({ name, namespace }: Props) => {
     status: "",
     pods: [],
   });
+  const [triggerReload, setTriggerReload] = useState<boolean>(false);
+
+  const handleTriggerReloadUpdate = () => {
+    setTriggerReload(!triggerReload);
+  };
 
   const [error, setError] = useState({
     message: "",
@@ -45,7 +50,7 @@ const Job = ({ name, namespace }: Props) => {
     return () => {
       clearInterval(interval);
     };
-  }, [name, namespace]);
+  }, [name, namespace, triggerReload]);
 
   return (
     <div>
@@ -73,7 +78,11 @@ const Job = ({ name, namespace }: Props) => {
           Pods: {job.pods.length}
         </Divider>
         <Col span={24} style={{ overflowX: "auto" }}>
-          <PodTable namespace={namespace} pods={job.pods} />
+          <PodTable
+            namespace={namespace}
+            pods={job.pods}
+            handleTriggerReloadUpdate={handleTriggerReloadUpdate}
+          />
         </Col>
       </Row>
     </div>

--- a/cyclops-ui/src/components/k8s-resources/StatefulSet.tsx
+++ b/cyclops-ui/src/components/k8s-resources/StatefulSet.tsx
@@ -19,6 +19,11 @@ const StatefulSet = ({ name, namespace }: Props) => {
     status: "",
     pods: [],
   });
+  const [triggerReload, setTriggerReload] = useState<boolean>(false);
+
+  const handleTriggerReloadUpdate = () => {
+    setTriggerReload(!triggerReload);
+  };
 
   const [error, setError] = useState({
     message: "",
@@ -27,6 +32,7 @@ const StatefulSet = ({ name, namespace }: Props) => {
 
   useEffect(() => {
     function fetchStatefulSet() {
+      console.log("fetchStatefulSet");
       axios
         .get(`/api/resources`, {
           params: {
@@ -50,7 +56,7 @@ const StatefulSet = ({ name, namespace }: Props) => {
     return () => {
       clearInterval(interval);
     };
-  }, [name, namespace]);
+  }, [name, namespace, triggerReload]);
 
   return (
     <div>
@@ -78,7 +84,11 @@ const StatefulSet = ({ name, namespace }: Props) => {
           Replicas: {statefulSet.pods.length}
         </Divider>
         <Col span={24} style={{ overflowX: "auto" }}>
-          <PodTable namespace={namespace} pods={statefulSet.pods} />
+          <PodTable
+            namespace={namespace}
+            pods={statefulSet.pods}
+            handleTriggerReloadUpdate={handleTriggerReloadUpdate}
+          />
         </Col>
       </Row>
     </div>

--- a/cyclops-ui/src/components/k8s-resources/common/PodTable/PodTable.tsx
+++ b/cyclops-ui/src/components/k8s-resources/common/PodTable/PodTable.tsx
@@ -28,6 +28,7 @@ import {
 interface Props {
   namespace: string;
   pods: any[];
+  handleTriggerReloadUpdate: () => void;
 }
 
 interface Pod {
@@ -38,7 +39,7 @@ interface Pod {
   namespace: any;
 }
 
-const PodTable = ({ pods, namespace }: Props) => {
+const PodTable = ({ pods, namespace, handleTriggerReloadUpdate }: Props) => {
   const [logs, setLogs] = useState("");
   const [logsModal, setLogsModal] = useState({
     on: false,
@@ -103,6 +104,8 @@ const PodTable = ({ pods, namespace }: Props) => {
           namespace: deletePodRef.podDetails.namespace,
         },
       });
+
+      handleTriggerReloadUpdate();
 
       setDeletePodConfirmRef("");
       setDeletePodRef({
@@ -450,7 +453,7 @@ const PodTable = ({ pods, namespace }: Props) => {
             Delete
           </Button>
         }
-        width={"30%"}
+        width={"40%"}
         styles={{
           footer: {
             display: "flex",
@@ -459,7 +462,7 @@ const PodTable = ({ pods, namespace }: Props) => {
         }}
       >
         <p>
-          In order to confirm deleting this resource, type:{" "}
+          In order to confirm deleting this resource, type: <br />{" "}
           <code>{deletePodRef.podDetails.name}</code>
         </p>
         <Input

--- a/cyclops-ui/src/components/k8s-resources/common/PodTable/PodTable.tsx
+++ b/cyclops-ui/src/components/k8s-resources/common/PodTable/PodTable.tsx
@@ -18,7 +18,11 @@ import ReactAce from "react-ace";
 import { mapResponseError } from "../../../../utils/api/errors";
 
 import styles from "./styles.module.css";
-import { EllipsisOutlined, ReadOutlined } from "@ant-design/icons";
+import {
+  EllipsisOutlined,
+  ReadOutlined,
+  DeleteOutlined,
+} from "@ant-design/icons";
 
 interface Props {
   namespace: string;
@@ -34,6 +38,15 @@ const PodTable = ({ pods, namespace }: Props) => {
     containers: [],
     initContainers: [],
   });
+
+  const [deletePodModal, setDeletePodModal] = useState<{
+    on: boolean;
+    podDetails: any;
+  }>({
+    on: false,
+    podDetails: {},
+  });
+
   const [error, setError] = useState({
     message: "",
     description: "",
@@ -48,6 +61,13 @@ const PodTable = ({ pods, namespace }: Props) => {
       initContainers: [],
     });
     setLogs("");
+  };
+
+  const handleCancelDeletePod = () => {
+    setDeletePodModal({
+      on: false,
+      podDetails: {},
+    });
   };
 
   const downloadLogs = (container: string) => {
@@ -203,6 +223,59 @@ const PodTable = ({ pods, namespace }: Props) => {
             View Logs
           </h4>
         </Button>
+        <Button
+          style={{ width: "60%", margin: "4px", color: "red " }}
+          onClick={function () {
+            console.log(
+              "Delete pod is clicked - soon starting with the implementation",
+            );
+            console.log(pod);
+
+            setDeletePodModal({
+              on: true,
+              podDetails: pod,
+            });
+
+            // axios
+            //   .get(
+            //     "/api/resources/pods/" +
+            //     namespace +
+            //     "/" +
+            //     pod.name +
+            //     "/" +
+            //     pod.containers[0].name +
+            //     "/logs",
+            //   )
+            //   .then((res) => {
+            //     if (res.data) {
+            //       let log = "";
+            //       res.data.forEach((s: string) => {
+            //         log += s;
+            //         log += "\n";
+            //       });
+            //       setLogs(log);
+            //     } else {
+            //       setLogs("No logs available");
+            //     }
+            //   })
+            //   .catch((error) => {
+            //     setError(mapResponseError(error));
+            //   });
+
+            // setLogsModal({
+            //   on: true,
+            //   namespace: namespace,
+            //   pod: pod.name,
+            //   containers: pod.containers,
+            //   initContainers: pod.initContainers,
+            // });
+          }}
+        >
+          <h4>
+            <DeleteOutlined style={{ paddingRight: "5px" }} />
+            Delete Pod
+          </h4>
+        </Button>
       </div>
     );
   };
@@ -312,6 +385,42 @@ const PodTable = ({ pods, namespace }: Props) => {
         )}
         <Tabs items={getTabItems()} onChange={onLogsTabsChange} />
       </Modal>
+      <Modal
+        title={
+          <div style={{ color: "red" }}>
+            <DeleteOutlined style={{ paddingRight: "5px" }} />
+            Delete{" "}
+            <span style={{ fontWeight: "bolder" }}>
+              {" "}
+              {deletePodModal.podDetails.name}{" "}
+            </span>{" "}
+            pod ?
+          </div>
+        }
+        open={deletePodModal.on}
+        onCancel={handleCancelDeletePod}
+        footer={
+          <Button
+            danger
+            block
+            disabled={false}
+            onClick={() => {
+              console.log(
+                "Delete pod is clicked - soon starting with the implementation",
+              );
+              console.log(deletePodModal.podDetails);
+
+              setDeletePodModal({
+                on: false,
+                podDetails: {},
+              });
+            }}
+          >
+            Yes
+          </Button>
+        }
+        width={"40%"}
+      ></Modal>
     </div>
   );
 };

--- a/cyclops-ui/src/components/k8s-resources/common/PodTable/PodTable.tsx
+++ b/cyclops-ui/src/components/k8s-resources/common/PodTable/PodTable.tsx
@@ -28,7 +28,7 @@ import {
 interface Props {
   namespace: string;
   pods: any[];
-  handleTriggerReloadUpdate: () => void;
+  updateResourceData: () => void;
 }
 
 interface Pod {
@@ -39,7 +39,7 @@ interface Pod {
   namespace: any;
 }
 
-const PodTable = ({ pods, namespace, handleTriggerReloadUpdate }: Props) => {
+const PodTable = ({ pods, namespace, updateResourceData }: Props) => {
   const [logs, setLogs] = useState("");
   const [logsModal, setLogsModal] = useState({
     on: false,
@@ -105,7 +105,7 @@ const PodTable = ({ pods, namespace, handleTriggerReloadUpdate }: Props) => {
         },
       });
 
-      handleTriggerReloadUpdate();
+      updateResourceData();
 
       setDeletePodConfirmRef("");
       setDeletePodRef({
@@ -248,78 +248,69 @@ const PodTable = ({ pods, namespace, handleTriggerReloadUpdate }: Props) => {
       <div style={{ width: "400px" }}>
         <h3>{pod.name} actions</h3>
         <Divider style={{ margin: "8px" }} />
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "row",
-            alignItems: "center",
-            justifyContent: "center",
+        <Button
+          style={{ width: "60%", margin: "4px" }}
+          onClick={function () {
+            axios
+              .get(
+                "/api/resources/pods/" +
+                  namespace +
+                  "/" +
+                  pod.name +
+                  "/" +
+                  pod.containers[0].name +
+                  "/logs",
+              )
+              .then((res) => {
+                if (res.data) {
+                  let log = "";
+                  res.data.forEach((s: string) => {
+                    log += s;
+                    log += "\n";
+                  });
+                  setLogs(log);
+                } else {
+                  setLogs("No logs available");
+                }
+              })
+              .catch((error) => {
+                setError(mapResponseError(error));
+              });
+
+            setLogsModal({
+              on: true,
+              namespace: namespace,
+              pod: pod.name,
+              containers: pod.containers,
+              initContainers: pod.initContainers,
+            });
           }}
         >
-          <Button
-            style={{ width: "60%", margin: "4px" }}
-            onClick={function () {
-              axios
-                .get(
-                  "/api/resources/pods/" +
-                    namespace +
-                    "/" +
-                    pod.name +
-                    "/" +
-                    pod.containers[0].name +
-                    "/logs",
-                )
-                .then((res) => {
-                  if (res.data) {
-                    let log = "";
-                    res.data.forEach((s: string) => {
-                      log += s;
-                      log += "\n";
-                    });
-                    setLogs(log);
-                  } else {
-                    setLogs("No logs available");
-                  }
-                })
-                .catch((error) => {
-                  setError(mapResponseError(error));
-                });
-
-              setLogsModal({
-                on: true,
+          <h4>
+            <ReadOutlined style={{ paddingRight: "5px" }} />
+            View Logs
+          </h4>
+        </Button>
+        <Button
+          style={{ width: "60%", margin: "4px", color: "red " }}
+          onClick={function () {
+            setDeletePodRef({
+              on: true,
+              podDetails: {
+                group: ``,
+                version: `v1`,
+                kind: `Pod`,
+                name: pod.name,
                 namespace: namespace,
-                pod: pod.name,
-                containers: pod.containers,
-                initContainers: pod.initContainers,
-              });
-            }}
-          >
-            <h4>
-              <ReadOutlined style={{ paddingRight: "5px" }} />
-              View Logs
-            </h4>
-          </Button>
-          <Button
-            style={{ width: "60%", margin: "4px", color: "red " }}
-            onClick={function () {
-              setDeletePodRef({
-                on: true,
-                podDetails: {
-                  group: ``,
-                  version: `v1`,
-                  kind: `Pod`,
-                  name: pod.name,
-                  namespace: namespace,
-                },
-              });
-            }}
-          >
-            <h4>
-              <DeleteOutlined style={{ paddingRight: "5px" }} />
-              Delete Pod
-            </h4>
-          </Button>
-        </div>
+              },
+            });
+          }}
+        >
+          <h4>
+            <DeleteOutlined style={{ paddingRight: "5px" }} />
+            Delete Pod
+          </h4>
+        </Button>
       </div>
     );
   };


### PR DESCRIPTION
closes #538

## 📑 Description

- Added a new `Delete` button to the Pod Actions Menu

![image](https://github.com/user-attachments/assets/13145cf5-3c33-4dc7-9123-e2c631041a04)

- Added a `Confirm Delete Modal` which confirms the deletion of pod and then makes a `DELETE` request to the backend endpoint `/resources`

![image](https://github.com/user-attachments/assets/08ad2fb2-860f-435e-968f-de65837ce0d9)

- Added a new `triggerReload` state to the components that uses `PodTable` component, so that upon the deletion of the pod we can manually fetch the resources from the parent component.
- Added a new Prop `handleTriggerReloadUpdate` to the `PodTable`, which is used to call the trigger in the parent component.

https://github.com/user-attachments/assets/9084e919-0d45-4a95-9bf1-8e172d5d2aac

## ✅ Checks
- [✅] I have tested my code (provide screenshots or screen recordings of a working solution)
- [✅] I have performed a self-review of my code

## ℹ Additional context
