### PR TITLE
feat: added view pod manifest

### DIFF
--- a/cyclops-ui/src/components/k8s-resources/common/PodTable/PodLogs.tsx
+++ b/cyclops-ui/src/components/k8s-resources/common/PodTable/PodLogs.tsx
@@ -1,0 +1,216 @@
+import { ReadOutlined } from "@ant-design/icons";
+import { Alert, Button, Col, Divider, Modal, Tabs, TabsProps } from "antd";
+import axios from "axios";
+import { useState } from "react";
+import { mapResponseError } from "../../../../utils/api/errors";
+import ReactAce from "react-ace/lib/ace";
+
+interface PodLogsProps {
+  pod: any;
+}
+
+const PodLogs = ({ pod }: PodLogsProps) => {
+  const [logs, setLogs] = useState("");
+  const [logsModal, setLogsModal] = useState({
+    on: false,
+    namespace: "",
+    pod: "",
+    containers: [],
+    initContainers: [],
+  });
+  const [error, setError] = useState({
+    message: "",
+    description: "",
+  });
+
+  const handleCancelLogs = () => {
+    setLogsModal({
+      on: false,
+      namespace: "",
+      pod: "",
+      containers: [],
+      initContainers: [],
+    });
+    setLogs("");
+  };
+
+  const getTabItems = () => {
+    let items: TabsProps["items"] = [];
+
+    let container: any;
+
+    if (logsModal.containers !== null) {
+      for (container of logsModal.containers) {
+        items.push({
+          key: container.name,
+          label: container.name,
+          children: (
+            <Col>
+              <Button
+                type="primary"
+                // icon={<DownloadOutlined />}
+                onClick={downloadLogs(container.name)}
+                disabled={logs === "No logs available"}
+              >
+                Download
+              </Button>
+              <Divider style={{ marginTop: "16px", marginBottom: "16px" }} />
+              <ReactAce
+                style={{ width: "100%" }}
+                mode={"sass"}
+                value={logs}
+                readOnly={true}
+              />
+            </Col>
+          ),
+        });
+      }
+    }
+
+    if (logsModal.initContainers !== null) {
+      for (container of logsModal.initContainers) {
+        items.push({
+          key: container.name,
+          label: "(init container) " + container.name,
+          children: (
+            <Col>
+              <Button
+                type="primary"
+                // icon={<DownloadOutlined />}
+                onClick={downloadLogs(container.name)}
+                disabled={logs === "No logs available"}
+              >
+                Download
+              </Button>
+              <Divider style={{ marginTop: "16px", marginBottom: "16px" }} />
+              <ReactAce
+                style={{ width: "100%" }}
+                mode={"sass"}
+                value={logs}
+                readOnly={true}
+              />
+            </Col>
+          ),
+        });
+      }
+    }
+
+    return items;
+  };
+
+  const onLogsTabsChange = (container: string) => {
+    axios
+      .get(
+        "/api/resources/pods/" +
+          logsModal.namespace +
+          "/" +
+          logsModal.pod +
+          "/" +
+          container +
+          "/logs",
+      )
+      .then((res) => {
+        if (res.data) {
+          let log = "";
+          res.data.forEach((s: string) => {
+            log += s;
+            log += "\n";
+          });
+          setLogs(log);
+        } else {
+          setLogs("No logs available");
+        }
+      })
+      .catch((error) => {
+        setError(mapResponseError(error));
+      });
+  };
+
+  const downloadLogs = (container: string) => {
+    return function () {
+      window.location.href =
+        "/api/resources/pods/" +
+        logsModal.namespace +
+        "/" +
+        logsModal.pod +
+        "/" +
+        container +
+        "/logs/download";
+    };
+  };
+
+  const handleViewPodLogs = async () => {
+    axios
+      .get(
+        "/api/resources/pods/" +
+          pod.namespace +
+          "/" +
+          pod.name +
+          "/" +
+          pod.containers[0].name +
+          "/logs",
+      )
+      .then((res) => {
+        if (res.data) {
+          let log = "";
+          res.data.forEach((s: string) => {
+            log += s;
+            log += "\n";
+          });
+          setLogs(log);
+        } else {
+          setLogs("No logs available");
+        }
+      })
+      .catch((error) => {
+        setError(mapResponseError(error));
+      });
+
+    setLogsModal({
+      on: true,
+      namespace: pod.namespace,
+      pod: pod.name,
+      containers: pod.containers,
+      initContainers: pod.initContainers,
+    });
+  };
+
+  return (
+    <>
+      <Col span={12} style={{ paddingRight: 4 }}>
+        <Button style={{ width: "100%" }} onClick={handleViewPodLogs}>
+          <h4>
+            <ReadOutlined style={{ paddingRight: "5px" }} />
+            View Logs
+          </h4>
+        </Button>
+      </Col>
+      <Modal
+        title="Logs"
+        open={logsModal.on}
+        onOk={handleCancelLogs}
+        onCancel={handleCancelLogs}
+        cancelButtonProps={{ style: { display: "none" } }}
+        width={"60%"}
+      >
+        {error.message.length !== 0 && (
+          <Alert
+            message={error.message}
+            description={error.description}
+            type="error"
+            closable
+            afterClose={() => {
+              setError({
+                message: "",
+                description: "",
+              });
+            }}
+            style={{ paddingBottom: "20px" }}
+          />
+        )}
+        <Tabs items={getTabItems()} onChange={onLogsTabsChange} />
+      </Modal>
+    </>
+  );
+};
+export default PodLogs;

--- a/cyclops-ui/src/components/k8s-resources/common/PodTable/PodLogs.tsx
+++ b/cyclops-ui/src/components/k8s-resources/common/PodTable/PodLogs.tsx
@@ -2,8 +2,8 @@ import { ReadOutlined } from "@ant-design/icons";
 import { Alert, Button, Col, Divider, Modal, Tabs, TabsProps } from "antd";
 import axios from "axios";
 import { useState } from "react";
-import { mapResponseError } from "../../../../utils/api/errors";
 import ReactAce from "react-ace/lib/ace";
+import { mapResponseError } from "../../../../utils/api/errors";
 
 interface PodLogsProps {
   pod: any;
@@ -177,14 +177,12 @@ const PodLogs = ({ pod }: PodLogsProps) => {
 
   return (
     <>
-      <Col span={12} style={{ paddingRight: 4 }}>
-        <Button style={{ width: "100%" }} onClick={handleViewPodLogs}>
-          <h4>
-            <ReadOutlined style={{ paddingRight: "5px" }} />
-            View Logs
-          </h4>
-        </Button>
-      </Col>
+      <Button style={{ width: "100%" }} onClick={handleViewPodLogs}>
+        <h4>
+          <ReadOutlined style={{ paddingRight: "5px" }} />
+          View Logs
+        </h4>
+      </Button>
       <Modal
         title="Logs"
         open={logsModal.on}

--- a/cyclops-ui/src/components/k8s-resources/common/PodTable/PodManifest.tsx
+++ b/cyclops-ui/src/components/k8s-resources/common/PodTable/PodManifest.tsx
@@ -1,5 +1,5 @@
-import { CopyOutlined } from "@ant-design/icons";
-import { Alert, Button, Checkbox, Col, Modal, Tooltip } from "antd";
+import { CopyOutlined, FileTextOutlined } from "@ant-design/icons";
+import { Alert, Button, Checkbox, Modal, Tooltip } from "antd";
 import { CheckboxChangeEvent } from "antd/es/checkbox";
 import axios from "axios";
 import { useCallback, useEffect, useState } from "react";
@@ -53,14 +53,17 @@ const PodManifest = ({ pod }: PodManifestProps) => {
   };
 
   return (
-    <Col span={12} style={{ paddingLeft: 4 }}>
+    <>
       <Button
         style={{ width: "100%" }}
         onClick={() => {
           setModal({ on: true });
         }}
       >
-        View Manifest
+        <h4>
+          <FileTextOutlined style={{ paddingRight: "5px" }} />
+          View Manifest
+        </h4>
       </Button>
       <Modal
         title={`Pod Manifest - ${pod.name}`}
@@ -132,7 +135,7 @@ const PodManifest = ({ pod }: PodManifestProps) => {
           </Button>
         </Tooltip>
       </Modal>
-    </Col>
+    </>
   );
 };
 export default PodManifest;

--- a/cyclops-ui/src/components/k8s-resources/common/PodTable/PodManifest.tsx
+++ b/cyclops-ui/src/components/k8s-resources/common/PodTable/PodManifest.tsx
@@ -1,0 +1,138 @@
+import { CopyOutlined } from "@ant-design/icons";
+import { Alert, Button, Checkbox, Col, Modal, Tooltip } from "antd";
+import { CheckboxChangeEvent } from "antd/es/checkbox";
+import axios from "axios";
+import { useCallback, useEffect, useState } from "react";
+import ReactAce from "react-ace/lib/ace";
+
+interface PodManifestProps {
+  pod: any;
+}
+
+const PodManifest = ({ pod }: PodManifestProps) => {
+  const [manifest, setManifest] = useState("");
+  const [showManagedFields, setShowManagedFields] = useState(false);
+  const [modal, setModal] = useState({
+    on: false,
+  });
+  const [error, setError] = useState({
+    message: "",
+    description: "",
+  });
+
+  const closeModal = () => {
+    setModal({
+      on: false,
+    });
+    setManifest("");
+  };
+
+  const fetchManifest = useCallback(async () => {
+    if (modal.on) {
+      const { group, name, namespace } = pod;
+      const { data: manifestData } = await axios.get(`/api/manifest`, {
+        params: {
+          group,
+          version: "v1",
+          kind: "Pod",
+          name,
+          namespace: namespace.length ? namespace : "default",
+          includeManagedFields: showManagedFields,
+        },
+      });
+      setManifest(manifestData);
+    }
+  }, [pod, showManagedFields, modal]);
+
+  useEffect(() => {
+    fetchManifest();
+  }, [showManagedFields, fetchManifest]);
+
+  const handleCheckboxChange = (e: CheckboxChangeEvent) => {
+    setShowManagedFields(e.target.checked);
+  };
+
+  return (
+    <Col span={12} style={{ paddingLeft: 4 }}>
+      <Button
+        style={{ width: "100%" }}
+        onClick={() => {
+          setModal({ on: true });
+        }}
+      >
+        View Manifest
+      </Button>
+      <Modal
+        title={`Pod Manifest - ${pod.name}`}
+        open={modal.on}
+        onOk={closeModal}
+        onCancel={closeModal}
+        cancelButtonProps={{ style: { display: "none" } }}
+        width={"60%"}
+      >
+        {error.message.length !== 0 && (
+          <Alert
+            message={error.message}
+            description={error.description}
+            type="error"
+            closable
+            afterClose={() => {
+              setError({
+                message: "",
+                description: "",
+              });
+            }}
+            style={{ paddingBottom: "20px" }}
+          />
+        )}
+        <Checkbox
+          onChange={handleCheckboxChange}
+          checked={showManagedFields}
+          style={{ marginBottom: "15px" }}
+        >
+          Include Managed Fields
+        </Checkbox>
+        <ReactAce
+          mode={"sass"}
+          theme={"github"}
+          fontSize={12}
+          showPrintMargin={true}
+          showGutter={true}
+          highlightActiveLine={true}
+          readOnly={true}
+          setOptions={{
+            enableBasicAutocompletion: true,
+            enableLiveAutocompletion: true,
+            enableSnippets: false,
+            showLineNumbers: true,
+            tabSize: 4,
+            useWorker: false,
+          }}
+          style={{
+            width: "100%",
+          }}
+          value={manifest}
+        />
+        <Tooltip title={"Copy Manifest"} trigger="hover">
+          <Button
+            onClick={() => {
+              navigator.clipboard.writeText(manifest);
+            }}
+            style={{
+              position: "absolute",
+              right: "50px",
+              top: "100px",
+            }}
+          >
+            <CopyOutlined
+              style={{
+                fontSize: "20px",
+              }}
+            />
+          </Button>
+        </Tooltip>
+      </Modal>
+    </Col>
+  );
+};
+export default PodManifest;

--- a/cyclops-ui/src/components/k8s-resources/common/PodTable/PodTable.tsx
+++ b/cyclops-ui/src/components/k8s-resources/common/PodTable/PodTable.tsx
@@ -2,7 +2,6 @@ import { DeleteOutlined, EllipsisOutlined } from "@ant-design/icons";
 import {
   Alert,
   Button,
-  Col,
   Divider,
   Input,
   Modal,
@@ -106,32 +105,30 @@ const PodTable = ({ pods, namespace, updateResourceData }: Props) => {
       <div style={{ width: "400px" }}>
         <h3>{pod.name} actions</h3>
         <Divider style={{ margin: "8px" }} />
-        <Row style={{ margin: 4 }}>
+        <Row style={{ margin: 4, gap: 8 }}>
           <PodLogs pod={{ ...pod, namespace }} />
           <PodManifest pod={{ ...pod, namespace }} />
-          <Col span={12} style={{ paddingRight: 4, marginTop: 10 }}>
-            <Button
-              style={{ color: "red", width: "100%" }}
-              onClick={function () {
-                setError({ message: "", description: "" });
-                setDeletePodRef({
-                  on: true,
-                  podDetails: {
-                    group: ``,
-                    version: `v1`,
-                    kind: `Pod`,
-                    name: pod.name,
-                    namespace: namespace,
-                  },
-                });
-              }}
-            >
-              <h4>
-                <DeleteOutlined style={{ paddingRight: "5px" }} />
-                Delete Pod
-              </h4>
-            </Button>
-          </Col>
+          <Button
+            style={{ color: "red", width: "100%" }}
+            onClick={function () {
+              setError({ message: "", description: "" });
+              setDeletePodRef({
+                on: true,
+                podDetails: {
+                  group: ``,
+                  version: `v1`,
+                  kind: `Pod`,
+                  name: pod.name,
+                  namespace: namespace,
+                },
+              });
+            }}
+          >
+            <h4>
+              <DeleteOutlined style={{ paddingRight: "5px" }} />
+              Delete Pod
+            </h4>
+          </Button>
         </Row>
       </div>
     );

--- a/cyclops-ui/src/components/k8s-resources/common/PodTable/styles.module.css
+++ b/cyclops-ui/src/components/k8s-resources/common/PodTable/styles.module.css
@@ -12,4 +12,5 @@
 .actionsmenu:hover {
   color: #fe8801;
   transform: scale(1.2);
+  cursor: pointer;
 }


### PR DESCRIPTION
closes [#539](https://github.com/cyclops-ui/cyclops/issues/539)

## 📑 Description

- Added View Manifest button to Pod Actions Menu

![Screenshot from 2024-09-02 17-43-57](https://github.com/user-attachments/assets/946b15da-1056-44d0-9ce7-24ef553d3afc)
![Screenshot from 2024-09-02 17-44-12](https://github.com/user-attachments/assets/b96adeaf-6ad3-4126-834c-22261e3e70ef)
![Screenshot from 2024-09-02 17-44-20](https://github.com/user-attachments/assets/f365142e-80a5-45b8-bf94-30b1e0b254a8)
![Screenshot from 2024-09-03 15-32-59](https://github.com/user-attachments/assets/cc775906-7ff3-41ed-9547-e1933bf58448)


## ✅ Checks
- [x] I have tested my code (provide screenshots or screen recordings of a working solution)
- [x] I have performed a self-review of my code

## ℹ Additional context
