### PR TITLE
🚀 feat: implement logs streaming for pods

### DIFF
--- a/cyclops-ctrl/internal/controller/modules.go
+++ b/cyclops-ctrl/internal/controller/modules.go
@@ -507,11 +507,11 @@ func (m *Modules) GetLogs(ctx *gin.Context) {
 
 	logCount := int64(100)
 
-	// pass on a channel to the GetPodLogs function to allow for streaming
 	logChan := make(chan string)
 
 	go func() {
 		defer close(logChan)
+
 		err := m.kubernetesClient.GetStreamedPodLogs(
 			ctx.Param("namespace"),
 			ctx.Param("container"),

--- a/cyclops-ctrl/internal/handler/handler.go
+++ b/cyclops-ctrl/internal/handler/handler.go
@@ -81,7 +81,7 @@ func (h *Handler) Start() error {
 	h.router.GET("/modules/:name/helm-template", modulesController.HelmTemplate)
 	//h.router.POST("/modules/resources", modulesController.ModuleToResources)
 
-	h.router.GET("/resources/pods/:namespace/:name/:container/logs", modulesController.GetLogs)
+	h.router.GET("/resources/pods/:namespace/:name/:container/logs", sse.HeadersMiddleware(), modulesController.GetLogs)
 	h.router.GET("/resources/pods/:namespace/:name/:container/logs/download", modulesController.DownloadLogs)
 
 	h.router.GET("/manifest", modulesController.GetManifest)

--- a/cyclops-ui/src/utils/api/sse/resources.tsx
+++ b/cyclops-ui/src/utils/api/sse/resources.tsx
@@ -54,3 +54,60 @@ export function resourceStream(
     },
   }).catch((r) => console.error(r));
 }
+
+export function logStream(
+  name: string,
+  namespace: string,
+  container: string,
+  setLog: (log: string) => void,
+  setError: (err: Error) => void,
+  signalController: AbortController,
+) {
+  fetchEventSource(
+    "/api/resources/pods" +
+      "/" +
+      namespace +
+      "/" +
+      name +
+      "/" +
+      container +
+      "/logs",
+    {
+      signal: signalController.signal,
+      method: "GET",
+      onmessage(ev) {
+        setLog(ev.data);
+      },
+      async onopen(response) {
+        if (
+          response.ok &&
+          response.headers.get("content-type") === EventStreamContentType
+        ) {
+          return;
+        } else if (
+          response.status >= 400 &&
+          response.status < 500 &&
+          response.status !== 429
+        ) {
+          throw new FatalError();
+        } else {
+          throw new RetriableError();
+        }
+      },
+      onclose() {
+        throw new RetriableError();
+      },
+      onerror: (err) => {
+        if (err instanceof FatalError) {
+          setError(err);
+          throw err; // rethrow to stop the operation
+        }
+
+        setError(err);
+        return 5000;
+      },
+    },
+  ).catch((r) => {
+    setError(r);
+  });
+}

--- a/cyclops-ui/yarn.lock
+++ b/cyclops-ui/yarn.lock
@@ -5278,9 +5278,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
-  version "1.0.30001597"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz#8be94a8c1d679de23b22fbd944232aa1321639e6"
-  integrity sha512-7LjJvmQU6Sj7bL0j5b5WY/3n7utXUJvAe1lxhsHDbLmwX9mdL86Yjtr+5SRCyf8qME4M7pU2hswj0FpyBVCv9w==
+  version "1.0.30001658"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001658.tgz"
+  integrity sha512-N2YVqWbJELVdrnsW5p+apoQyYt51aBMSsBZki1XZEfeBCexcM/sf4xiAHcXQBkuOwJBXtWF7aW1sYX6tKebPHw==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"
@@ -13406,7 +13406,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13498,7 +13507,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13511,6 +13520,13 @@ strip-ansi@^3.0.0:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -14839,7 +14855,7 @@ workbox-window@6.6.1:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.6.1"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -14852,6 +14868,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
closes #555 

## 📑 Description
[BE]
- Implemented streaming logs of pod continuously to the client using SSE.
- Utilized previously coded SSE implementation and made channels to stream the logs to the FE.

[FE]
- Changed `logs` state to store array of strings to easily manage logs by using `logs.join("\n")`.
- Implemented `logStream` function which streams the logs and sets it in the state.
- Handled scenario when no logs are available, container tabs are changed and when the log modal is cancelled or OKed.
- Introduced a new `logsSignalController` state to be passed to the `logStream` function to handle the SSE connection scenarios i.e. close the connection via signal when modal is closed, close the current connection via signal and make a new signal for the new connection when the container tab is changed.

Streamed Logs Demo + No more events fired after the modal is closed:
https://github.com/user-attachments/assets/1f3f5fdf-102d-4697-9188-002092279098


## ✅ Checks
- [✅] I have tested my code (provide screenshots or screen recordings of a working solution)
- [✅] I have performed a self-review of my code

## ℹ Additional context
