### PR TITLE
fetch container logs when streaming disabled

### DIFF
--- a/cyclops-ctrl/internal/handler/handler.go
+++ b/cyclops-ctrl/internal/handler/handler.go
@@ -83,7 +83,8 @@ func (h *Handler) Start() error {
 	h.router.GET("/modules/:name/helm-template", modulesController.HelmTemplate)
 	//h.router.POST("/modules/resources", modulesController.ModuleToResources)
 
-	h.router.GET("/resources/pods/:namespace/:name/:container/logs", sse.HeadersMiddleware(), modulesController.GetLogs)
+	h.router.GET("/resources/pods/:namespace/:name/:container/logs", modulesController.GetLogs)
+	h.router.GET("/resources/pods/:namespace/:name/:container/logs/stream", sse.HeadersMiddleware(), modulesController.GetLogsStream)
 	h.router.GET("/resources/pods/:namespace/:name/:container/logs/download", modulesController.DownloadLogs)
 
 	h.router.GET("/manifest", modulesController.GetManifest)

--- a/cyclops-ui/src/components/k8s-resources/common/PodTable/PodLogs.tsx
+++ b/cyclops-ui/src/components/k8s-resources/common/PodTable/PodLogs.tsx
@@ -1,10 +1,11 @@
-import { ReadOutlined } from "@ant-design/icons";
+import { DownloadOutlined, ReadOutlined } from "@ant-design/icons";
 import { Alert, Button, Col, Divider, Modal, Tabs, TabsProps } from "antd";
 import { useState } from "react";
 import ReactAce from "react-ace/lib/ace";
 import { mapResponseError } from "../../../../utils/api/errors";
 import { isStreamingEnabled } from "../../../../utils/api/common";
 import { logStream } from "../../../../utils/api/sse/logs";
+import axios from "axios";
 
 interface PodLogsProps {
   pod: any;
@@ -134,6 +135,27 @@ const PodLogs = ({ pod }: PodLogsProps) => {
         },
         controller,
       );
+    } else {
+      axios
+        .get(
+          "/api/resources/pods/" +
+            logsModal.namespace +
+            "/" +
+            logsModal.pod +
+            "/" +
+            container +
+            "/logs",
+        )
+        .then((res) => {
+          if (res.data) {
+            setLogs(res.data);
+          } else {
+            setLogs(() => []);
+          }
+        })
+        .catch((error) => {
+          setError(mapResponseError(error));
+        });
     }
   };
 
@@ -182,6 +204,27 @@ const PodLogs = ({ pod }: PodLogsProps) => {
               },
               controller,
             );
+          } else {
+            axios
+              .get(
+                "/api/resources/pods/" +
+                  pod.namespace +
+                  "/" +
+                  pod.name +
+                  "/" +
+                  pod.containers[0].name +
+                  "/logs",
+              )
+              .then((res) => {
+                if (res.data) {
+                  setLogs(res.data);
+                } else {
+                  setLogs(() => []);
+                }
+              })
+              .catch((error) => {
+                setError(mapResponseError(error));
+              });
           }
 
           setLogsModal({

--- a/cyclops-ui/src/components/k8s-resources/common/PodTable/PodLogs.tsx
+++ b/cyclops-ui/src/components/k8s-resources/common/PodTable/PodLogs.tsx
@@ -1,4 +1,4 @@
-import { DownloadOutlined, ReadOutlined } from "@ant-design/icons";
+import { ReadOutlined } from "@ant-design/icons";
 import { Alert, Button, Col, Divider, Modal, Tabs, TabsProps } from "antd";
 import { useState } from "react";
 import ReactAce from "react-ace/lib/ace";

--- a/cyclops-ui/src/utils/api/sse/logs.tsx
+++ b/cyclops-ui/src/utils/api/sse/logs.tsx
@@ -22,7 +22,7 @@ export function logStream(
       name +
       "/" +
       container +
-      "/logs",
+      "/logs/stream",
     {
       signal: signalController.signal,
       method: "GET",


### PR DESCRIPTION
Fetches container logs using `axios.get` if streaming is disabled. Mentioned in #568 