### PR TITLE
🚀 feat(cyctl): disable streaming flag

### DIFF
--- a/cyctl/cmd/apply.go
+++ b/cyctl/cmd/apply.go
@@ -224,7 +224,7 @@ var applyCmd = &cobra.Command{
 
 func init() {
 	applyCmd.Flags().StringP("version", "v", "main", "specify cyclops version")
-	applyCmd.Flags().BoolP("disable-streaming", "s", false, "disable streaming resources when installing Cyclops")
+	applyCmd.Flags().BoolP("disable-streaming", "s", false, "turn off streaming of updates to the UI")
 	applyCmd.Flags().BoolP("disable-telemetry", "t", false, "disable emitting telemetry metrics from cyclops controller")
 	RootCmd.AddCommand(applyCmd)
 }


### PR DESCRIPTION
closes #603 

## 📑 Description

### If no filter used, REACT_APP_ENABLE_STREAMING is True

![Cyclops — Zen Browser 10_4_2024 8_26_56 PM](https://github.com/user-attachments/assets/240ba557-5899-4d82-b451-c7239a62a90a)

![Cyclops — Zen Browser 10_4_2024 8_26_45 PM](https://github.com/user-attachments/assets/b40ff193-7d86-487c-8099-f9410251871b)

### If `--disable-streaming` or `-s` filter used, REACT_APP_ENABLE_STREAMING is False


![Cyclops — Zen Browser 10_4_2024 8_27_47 PM](https://github.com/user-attachments/assets/d7bcd3d6-0307-4dc3-8630-6e080ceac849)

![Cyclops — Zen Browser 10_4_2024 8_28_37 PM](https://github.com/user-attachments/assets/c2d7fa21-c46a-4608-b33f-dd2f21247df4)



## ✅ Checks
- [x] I have tested my code (provide screenshots or screen recordings of a working solution)
- [x] I have performed a self-review of my code

## ℹ Additional context
