### PR TITLE
🚀feat(cyclops-ctrl): adds prometheus metrics to reconciler

### DIFF
--- a/cyclops-ctrl/cmd/main/main.go
+++ b/cyclops-ctrl/cmd/main/main.go
@@ -126,6 +126,7 @@ func main() {
 		k8sClient,
 		renderer,
 		telemetryClient,
+		monitor,
 	)).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Module")
 		os.Exit(1)

--- a/cyclops-ctrl/internal/modulecontroller/module_controller.go
+++ b/cyclops-ctrl/internal/modulecontroller/module_controller.go
@@ -96,7 +96,7 @@ func NewModuleReconciler(
 func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 	r.telemetryClient.ModuleReconciliation()
-	r.monitor.IncNoOfReconcilations()
+	r.monitor.IncNoOfReconciliations()
 
 	startTime := time.Now()
 
@@ -111,7 +111,7 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		resources, err := r.kubernetesClient.GetResourcesForModule(req.Name)
 		if err != nil {
 			r.logger.Error(err, "error on get module resources", "namespaced name", req.NamespacedName)
-			r.monitor.IncFailedReconcilations()
+			r.monitor.IncFailedReconciliations()
 			return ctrl.Result{}, err
 		}
 
@@ -131,7 +131,7 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 	if err != nil {
-		r.monitor.IncFailedReconcilations()
+		r.monitor.IncFailedReconciliations()
 		return ctrl.Result{}, err
 	}
 
@@ -155,7 +155,7 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, err
 		}
 
-		r.monitor.IncFailedReconcilations()
+		r.monitor.IncFailedReconciliations()
 
 		return ctrl.Result{}, err
 	}
@@ -168,13 +168,13 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, err
 		}
 
-		r.monitor.IncFailedReconcilations()
+		r.monitor.IncFailedReconciliations()
 
 		return ctrl.Result{}, err
 	}
 
 	if len(installErrors) != 0 {
-		r.monitor.IncFailedReconcilations()
+		r.monitor.IncFailedReconciliations()
 		return ctrl.Result{}, r.setStatus(
 			ctx,
 			module,

--- a/cyclops-ctrl/internal/prometheus/handler.go
+++ b/cyclops-ctrl/internal/prometheus/handler.go
@@ -20,8 +20,8 @@ type Monitor struct {
 
 	// Reconciler Metrics
 	ReconcilerDuration   prometheus.Histogram
-	NoOfReconcilations   prometheus.Counter
-	FailedReconcilations prometheus.Counter
+	NoOfReconciliations   prometheus.Counter
+	FailedReconciliations prometheus.Counter
 }
 
 func NewMonitor(logger logr.Logger) (Monitor, error) {
@@ -68,14 +68,14 @@ func NewMonitor(logger logr.Logger) (Monitor, error) {
 			Namespace: "cyclops",
 			Buckets:   prometheus.DefBuckets,
 		}),
-		NoOfReconcilations: prometheus.NewCounter(prometheus.CounterOpts{
-			Name:      "no_of_reconcilations",
-			Help:      "No of reconcilations",
+		NoOfReconciliations: prometheus.NewCounter(prometheus.CounterOpts{
+			Name:      "no_of_reconciliations",
+			Help:      "No of reconciliations",
 			Namespace: "cyclops",
 		}),
-		FailedReconcilations: prometheus.NewCounter(prometheus.CounterOpts{
-			Name:      "failed_reconcilations",
-			Help:      "No of failed reconcilations",
+		FailedReconciliations: prometheus.NewCounter(prometheus.CounterOpts{
+			Name:      "failed_reconciliations",
+			Help:      "No of failed reconciliations",
 			Namespace: "cyclops",
 		}),
 	}
@@ -90,8 +90,8 @@ func NewMonitor(logger logr.Logger) (Monitor, error) {
 			m.CacheKeysEvicted,
 			m.CacheCostEvicted,
 			m.ReconcilerDuration,
-			m.NoOfReconcilations,
-			m.FailedReconcilations,
+			m.NoOfReconciliations,
+			m.FailedReconciliations,
 		}
 
 	for _, metric := range metricsList {
@@ -112,12 +112,12 @@ func (m *Monitor) DecModule() {
 	m.ModulesDeployed.Dec()
 }
 
-func (m *Monitor) IncNoOfReconcilations() {
-	m.NoOfReconcilations.Inc()
+func (m *Monitor) IncNoOfReconciliations() {
+	m.NoOfReconciliations.Inc()
 }
 
-func (m *Monitor) IncFailedReconcilations() {
-	m.FailedReconcilations.Inc()
+func (m *Monitor) IncFailedReconciliations() {
+	m.FailedReconciliations.Inc()
 }
 
 func (m *Monitor) ObserveReconcilerDuration(duration float64) {

--- a/cyclops-ctrl/internal/prometheus/handler.go
+++ b/cyclops-ctrl/internal/prometheus/handler.go
@@ -19,9 +19,9 @@ type Monitor struct {
 	CacheCostEvicted prometheus.Gauge
 
 	// Reconciler Metrics
-	ReconcilerDuration   prometheus.Histogram
-	NoOfReconciliations   prometheus.Counter
-	FailedReconciliations prometheus.Counter
+	ReconciliationDuration      prometheus.Histogram
+	ReconciliationCounter       prometheus.Counter
+	FailedReconciliationCounter prometheus.Counter
 }
 
 func NewMonitor(logger logr.Logger) (Monitor, error) {
@@ -62,18 +62,18 @@ func NewMonitor(logger logr.Logger) (Monitor, error) {
 			Help:      "No of cache cost evicted",
 			Namespace: "cyclops",
 		}),
-		ReconcilerDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Name:      "reconciler_duration_seconds",
+		ReconciliationDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:      "reconciliation_duration_seconds",
 			Help:      "Duration of reconciler",
 			Namespace: "cyclops",
 			Buckets:   prometheus.DefBuckets,
 		}),
-		NoOfReconciliations: prometheus.NewCounter(prometheus.CounterOpts{
+		ReconciliationCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Name:      "no_of_reconciliations",
 			Help:      "No of reconciliations",
 			Namespace: "cyclops",
 		}),
-		FailedReconciliations: prometheus.NewCounter(prometheus.CounterOpts{
+		FailedReconciliationCounter: prometheus.NewCounter(prometheus.CounterOpts{
 			Name:      "failed_reconciliations",
 			Help:      "No of failed reconciliations",
 			Namespace: "cyclops",
@@ -89,9 +89,9 @@ func NewMonitor(logger logr.Logger) (Monitor, error) {
 			m.CacheCostAdded,
 			m.CacheKeysEvicted,
 			m.CacheCostEvicted,
-			m.ReconcilerDuration,
-			m.NoOfReconciliations,
-			m.FailedReconciliations,
+			m.ReconciliationDuration,
+			m.ReconciliationCounter,
+			m.FailedReconciliationCounter,
 		}
 
 	for _, metric := range metricsList {
@@ -112,16 +112,16 @@ func (m *Monitor) DecModule() {
 	m.ModulesDeployed.Dec()
 }
 
-func (m *Monitor) IncNoOfReconciliations() {
-	m.NoOfReconciliations.Inc()
+func (m *Monitor) OnReconciliation() {
+	m.ReconciliationCounter.Inc()
 }
 
-func (m *Monitor) IncFailedReconciliations() {
-	m.FailedReconciliations.Inc()
+func (m *Monitor) OnFailedReconciliation() {
+	m.FailedReconciliationCounter.Inc()
 }
 
-func (m *Monitor) ObserveReconcilerDuration(duration float64) {
-	m.ReconcilerDuration.Observe(duration)
+func (m *Monitor) ObserveReconciliationDuration(duration float64) {
+	m.ReconciliationDuration.Observe(duration)
 }
 
 func (m *Monitor) UpdateCacheMetrics(cache *ristretto.Cache) {


### PR DESCRIPTION
closes #598

## 📑 Description
- added required reconciler metrics to the Prometheus monitor
- currently added metrics are 
```go
type Monitor struct {
	ModulesDeployed  prometheus.Gauge
	CacheHits        prometheus.Gauge
	CacheMisses      prometheus.Gauge
	CacheKeysAdded   prometheus.Gauge
	CacheCostAdded   prometheus.Gauge
	CacheKeysEvicted prometheus.Gauge
	CacheCostEvicted prometheus.Gauge

	// Reconciler Metrics
	ReconcilerDuration   prometheus.Histogram
	NoOfReconciliations   prometheus.Counter
	FailedReconciliations prometheus.Counter
}
```
- added methods to update the reconciler metrics
- added increment for `no_of_reconciliations` for every attempted reconciliation
- added increment for `failed_reconciliations` for every failed reconciliation
- added deferred function call to observe the amount of time spent in reconciliation 

## ✅ Checks
- [✅] I have tested my code (provide screenshots or screen recordings of a working solution)
- [✅] I have performed a self-review of my code

## ℹ Additional context
