### PR TITLE
🚀 feat(cyctl): Show TemplateResolvedVersion on cyctl `describe module`

### DIFF
--- a/cyctl/internal/describe/modules.go
+++ b/cyctl/internal/describe/modules.go
@@ -50,6 +50,7 @@ func describeModules(clientset *client.CyclopsV1Alpha1Client, moduleNames []stri
 			d.Printf("  Repository:\t%s\n", module.Spec.TemplateRef.URL)
 			d.Printf("  Relative Path:\t%s\n", module.Spec.TemplateRef.Path)
 			d.Printf("  Branch:\t%s\n", module.Spec.TemplateRef.Version)
+			d.Printf("  Resolved Version:\t%s\n", module.Status.TemplateResolvedVersion)
 
 			d.Println()
 			if len(module.Spec.Values.Raw) > 0 {


### PR DESCRIPTION
closes #605

## 📑 Description
![image](https://github.com/user-attachments/assets/e4175fc5-5701-4ef7-a1d6-b74d04474e75)



## ✅ Checks
- [x] I have tested my code (provide screenshots or screen recordings of a working solution)
- [x] I have performed a self-review of my code

## ℹ Additional context
is this what expected?