### PR TITLE
🚀 feat: adds `ReplicaSet` in Deployments

### DIFF
--- a/cyclops-ctrl/internal/models/dto/k8s.go
+++ b/cyclops-ctrl/internal/models/dto/k8s.go
@@ -19,16 +19,16 @@ type Resource interface {
 }
 
 type Deployment struct {
-	Group      string       `json:"group"`
-	Version    string       `json:"version"`
-	Kind       string       `json:"kind"`
-	Name       string       `json:"name"`
-	Namespace  string       `json:"namespace"`
-	Replicas   int          `json:"replicas"`
-	ReplicaSet []ReplicaSet `json:"replicaset"`
-	Pods       []Pod        `json:"pods"`
-	Status     string       `json:"status"`
-	Deleted    bool         `json:"deleted"`
+	Group       string       `json:"group"`
+	Version     string       `json:"version"`
+	Kind        string       `json:"kind"`
+	Name        string       `json:"name"`
+	Namespace   string       `json:"namespace"`
+	Replicas    int          `json:"replicas"`
+	ReplicaSets []ReplicaSet `json:"replicaSets"`
+	Pods        []Pod        `json:"pods"`
+	Status      string       `json:"status"`
+	Deleted     bool         `json:"deleted"`
 }
 
 func (d *Deployment) GetGroupVersionKind() string {
@@ -204,15 +204,17 @@ type ContainerStatus struct {
 }
 
 type ReplicaSet struct {
-	Group                string `json:"group"`
-	Version              string `json:"version"`
-	Kind                 string `json:"kind"`
-	Name                 string `json:"name"`
-	Namespace            string `json:"namespace"`
-	Replicas             int32  `json:"replicas"`
-	FullyLabeledReplicas int32  `json:"fullyLabeledReplicas"`
-	ReadyReplicas        int32  `json:"readyReplicas"`
-	AvailableReplicas    int32  `json:"availableReplicas"`
+	Group                string      `json:"group"`
+	Version              string      `json:"version"`
+	Kind                 string      `json:"kind"`
+	Name                 string      `json:"name"`
+	Namespace            string      `json:"namespace"`
+	Replicas             int32       `json:"replicas"`
+	FullyLabeledReplicas int32       `json:"fullyLabeledReplicas"`
+	ReadyReplicas        int32       `json:"readyReplicas"`
+	AvailableReplicas    int32       `json:"availableReplicas"`
+	Started              metav1.Time `json:"started"`
+	Deleted              bool        `json:"deleted"`
 }
 
 type Pod struct {

--- a/cyclops-ctrl/internal/models/dto/k8s.go
+++ b/cyclops-ctrl/internal/models/dto/k8s.go
@@ -19,15 +19,16 @@ type Resource interface {
 }
 
 type Deployment struct {
-	Group     string `json:"group"`
-	Version   string `json:"version"`
-	Kind      string `json:"kind"`
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-	Replicas  int    `json:"replicas"`
-	Pods      []Pod  `json:"pods"`
-	Status    string `json:"status"`
-	Deleted   bool   `json:"deleted"`
+	Group      string       `json:"group"`
+	Version    string       `json:"version"`
+	Kind       string       `json:"kind"`
+	Name       string       `json:"name"`
+	Namespace  string       `json:"namespace"`
+	Replicas   int          `json:"replicas"`
+	ReplicaSet []ReplicaSet `json:"replicaset"`
+	Pods       []Pod        `json:"pods"`
+	Status     string       `json:"status"`
+	Deleted    bool         `json:"deleted"`
 }
 
 func (d *Deployment) GetGroupVersionKind() string {
@@ -200,6 +201,18 @@ type ContainerStatus struct {
 	Status  string `json:"status"`
 	Message string `json:"message"`
 	Running bool   `json:"running"`
+}
+
+type ReplicaSet struct {
+	Group                string `json:"group"`
+	Version              string `json:"version"`
+	Kind                 string `json:"kind"`
+	Name                 string `json:"name"`
+	Namespace            string `json:"namespace"`
+	Replicas             int32  `json:"replicas"`
+	FullyLabeledReplicas int32  `json:"fullyLabeledReplicas"`
+	ReadyReplicas        int32  `json:"readyReplicas"`
+	AvailableReplicas    int32  `json:"availableReplicas"`
 }
 
 type Pod struct {

--- a/cyclops-ctrl/pkg/cluster/k8sclient/mapper.go
+++ b/cyclops-ctrl/pkg/cluster/k8sclient/mapper.go
@@ -29,15 +29,15 @@ func (k *KubernetesClient) mapDeployment(group, version, kind, name, namespace s
 	}
 
 	return &dto.Deployment{
-		Group:      group,
-		Version:    version,
-		Kind:       kind,
-		Name:       deployment.Name,
-		Namespace:  deployment.Namespace,
-		Replicas:   int(*deployment.Spec.Replicas),
-		ReplicaSet: replicaSets,
-		Pods:       pods,
-		Status:     getDeploymentStatus(deployment),
+		Group:       group,
+		Version:     version,
+		Kind:        kind,
+		Name:        deployment.Name,
+		Namespace:   deployment.Namespace,
+		Replicas:    int(*deployment.Spec.Replicas),
+		ReplicaSets: replicaSets,
+		Pods:        pods,
+		Status:      getDeploymentStatus(deployment),
 	}, nil
 }
 

--- a/cyclops-ctrl/pkg/cluster/k8sclient/mapper.go
+++ b/cyclops-ctrl/pkg/cluster/k8sclient/mapper.go
@@ -17,20 +17,27 @@ func (k *KubernetesClient) mapDeployment(group, version, kind, name, namespace s
 		return nil, err
 	}
 
+	// map replicaset here
+	replicaSets, err := k.getReplicaset(*deployment)
+	if err != nil {
+		return nil, err
+	}
+
 	pods, err := k.getPods(*deployment)
 	if err != nil {
 		return nil, err
 	}
 
 	return &dto.Deployment{
-		Group:     group,
-		Version:   version,
-		Kind:      kind,
-		Name:      deployment.Name,
-		Namespace: deployment.Namespace,
-		Replicas:  int(*deployment.Spec.Replicas),
-		Pods:      pods,
-		Status:    getDeploymentStatus(deployment),
+		Group:      group,
+		Version:    version,
+		Kind:       kind,
+		Name:       deployment.Name,
+		Namespace:  deployment.Namespace,
+		Replicas:   int(*deployment.Spec.Replicas),
+		ReplicaSet: replicaSets,
+		Pods:       pods,
+		Status:     getDeploymentStatus(deployment),
 	}, nil
 }
 

--- a/cyclops-ui/src/components/k8s-resources/Deployment.tsx
+++ b/cyclops-ui/src/components/k8s-resources/Deployment.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useEffect, useState } from "react";
-import { Col, Divider, Row, Alert } from "antd";
+import { Alert, Col, Divider, Row } from "antd";
 import axios from "axios";
+import { useCallback, useEffect, useState } from "react";
+import { isStreamingEnabled } from "../../utils/api/common";
 import { mapResponseError } from "../../utils/api/errors";
 import PodTable from "./common/PodTable/PodTable";
-import { isStreamingEnabled } from "../../utils/api/common";
+import ReplicaSet from "./ReplicaSet";
 
 interface Props {
   name: string;
@@ -15,6 +16,7 @@ const Deployment = ({ name, namespace, workload }: Props) => {
   const [deployment, setDeployment] = useState({
     status: "",
     pods: [],
+    replicaSets: [],
   });
   const [error, setError] = useState({
     message: "",
@@ -61,6 +63,24 @@ const Deployment = ({ name, namespace, workload }: Props) => {
     return deployment.pods;
   }
 
+  function getReplicaSets() {
+    if (workload && isStreamingEnabled()) {
+      return workload.replicaSets;
+    }
+
+    return deployment.replicaSets;
+  }
+
+  function sortReplicaSets(replicaSets: any[]) {
+    return replicaSets.sort((a, b) => {
+      if (a.replicas === b.replicas) {
+        return new Date(b.started).getTime() - new Date(a.started).getTime(); // descending on started time
+      }
+
+      return b.replicas - a.replicas; // descending on replicas
+    });
+  }
+
   function getPodsLength() {
     let pods = getPods();
 
@@ -89,6 +109,16 @@ const Deployment = ({ name, namespace, workload }: Props) => {
         />
       )}
       <Row>
+        <Divider
+          style={{ fontSize: "120%" }}
+          orientationMargin="0"
+          orientation={"left"}
+        >
+          Replica Sets: {getReplicaSets().length}
+        </Divider>
+        <Col span={24} style={{ overflowX: "auto" }}>
+          <ReplicaSet replicaSets={sortReplicaSets(getReplicaSets())} />
+        </Col>
         <Divider
           style={{ fontSize: "120%" }}
           orientationMargin="0"

--- a/cyclops-ui/src/components/k8s-resources/ReplicaSet.tsx
+++ b/cyclops-ui/src/components/k8s-resources/ReplicaSet.tsx
@@ -1,0 +1,33 @@
+import { Table } from "antd";
+import { formatReplicaSetAge } from "../../utils/replicaset";
+
+interface ReplicaSetType {
+  replicaSets: any[];
+}
+
+const ReplicaSet = ({ replicaSets }: ReplicaSetType) => {
+  return (
+    <div>
+      <Table dataSource={replicaSets}>
+        <Table.Column
+          title="Name"
+          dataIndex="name"
+          filterSearch={true}
+          key="name"
+        />
+        <Table.Column title="Desired Replicas" dataIndex="replicas" />
+        <Table.Column title="Current Replicas" dataIndex="availableReplicas" />
+        <Table.Column title="Ready Replicas" dataIndex="readyReplicas" />
+        <Table.Column
+          title="Started"
+          dataIndex="started"
+          render={(value) => {
+            return <>{formatReplicaSetAge(value)}</>;
+          }}
+        />
+      </Table>
+    </div>
+  );
+};
+
+export default ReplicaSet;

--- a/cyclops-ui/src/components/pages/ModuleDetails.tsx
+++ b/cyclops-ui/src/components/pages/ModuleDetails.tsx
@@ -1,4 +1,15 @@
-import React, { useEffect, useState, useCallback } from "react";
+import {
+  BookOutlined,
+  CheckCircleTwoTone,
+  ClockCircleTwoTone,
+  CloseSquareTwoTone,
+  CopyOutlined,
+  DeleteOutlined,
+  EditOutlined,
+  FileTextOutlined,
+  UndoOutlined,
+} from "@ant-design/icons";
+import "ace-builds/src-noconflict/ace";
 import {
   Alert,
   Button,
@@ -13,40 +24,29 @@ import {
   Tooltip,
   Typography,
 } from "antd";
-import "ace-builds/src-noconflict/ace";
-import { useParams } from "react-router-dom";
 import axios from "axios";
-import {
-  BookOutlined,
-  CheckCircleTwoTone,
-  ClockCircleTwoTone,
-  CloseSquareTwoTone,
-  CopyOutlined,
-  DeleteOutlined,
-  EditOutlined,
-  FileTextOutlined,
-  UndoOutlined,
-} from "@ant-design/icons";
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 import "./custom.css";
 
 import "ace-builds/src-noconflict/mode-jsx";
 import ReactAce from "react-ace";
 
-import {
-  moduleTemplateReferenceView,
-  templateRef,
-} from "../../utils/templateRef";
-import { mapResponseError } from "../../utils/api/errors";
 import YAML from "yaml";
 import { isStreamingEnabled } from "../../utils/api/common";
+import { mapResponseError } from "../../utils/api/errors";
 import { resourcesStream } from "../../utils/api/sse/resources";
+import { Workload } from "../../utils/k8s/workload";
 import {
   isWorkload,
   ResourceRef,
   resourceRefKey,
 } from "../../utils/resourceRef";
+import {
+  moduleTemplateReferenceView,
+  templateRef,
+} from "../../utils/templateRef";
 import ResourceList from "../k8s-resources/ResourceList/ResourceList";
-import { Workload } from "../../utils/k8s/workload";
 
 const languages = [
   "javascript",

--- a/cyclops-ui/src/utils/replicaset.tsx
+++ b/cyclops-ui/src/utils/replicaset.tsx
@@ -1,0 +1,12 @@
+import { formatDistanceToNow } from "date-fns";
+
+export const formatReplicaSetAge = (creationTimestamp: string) => {
+  if (creationTimestamp === null || creationTimestamp === "") {
+    return "";
+  }
+
+  const parsedDate = new Date(creationTimestamp);
+  return formatDistanceToNow(parsedDate, {
+    addSuffix: true,
+  });
+};


### PR DESCRIPTION
closes #147

## 📑 Description

[BE]
- Added a new DTO, ReplicaSet, and its helper methods, which will be populated when fetching the details of the deployment.

[FE]
- Added a new ReplicaSet section to the deployment details page of the module.

![image](https://github.com/user-attachments/assets/c695c5c3-92e6-4a8e-9d7e-d1271963aba4)

## ✅ Checks
- [✅] I have tested my code (provide screenshots or screen recordings of a working solution)
- [✅] I have performed a self-review of my code

## ℹ Additional context
