### PR TITLE
support anyOf in json schema

### DIFF
--- a/cyclops-ctrl/internal/models/helm/helmschema.go
+++ b/cyclops-ctrl/internal/models/helm/helmschema.go
@@ -31,6 +31,9 @@ type Property struct {
 	MinLength *int    `json:"minLength"`
 	MaxLength *int    `json:"maxLength"`
 	Pattern   *string `json:"pattern"`
+
+	// schema compositions
+	AnyOf []Property `json:"anyOf"`
 }
 
 type PropertyType string


### PR DESCRIPTION
Add support for `anyOf` in JSON schema. Since there are multiple options for an anyOf, Cyclops looks for the one that has a type `boolean` because it's the easiest input form. If there are multiple `boolean` options, Cyclops takes the first one. If there are none, Cyclops takes the first definition from the anyOf