### PR TITLE
remove gin router init in handler constructor

### DIFF
--- a/cyclops-ctrl/internal/handler/handler.go
+++ b/cyclops-ctrl/internal/handler/handler.go
@@ -45,7 +45,6 @@ func New(
 		moduleTargetNamespace: moduleTargetNamespace,
 		telemetryClient:       telemetryClient,
 		monitor:               monitor,
-		router:                gin.New(),
 	}, nil
 }
 


### PR DESCRIPTION
removes router init to prevet double logging of gin mode