### PR TITLE
Fix "nginx" typo in Cyclops: Platform Engineering for the Rest of Us

### DIFF
--- a/web/blog/2025-02-03-PE-for-the-rest-of-us/index.md
+++ b/web/blog/2025-02-03-PE-for-the-rest-of-us/index.md
@@ -85,7 +85,7 @@ kubectl port-forward svc/cyclops-ui 3000:3000 -n cyclops
 
 Next, connect to the UI with your browser at http://localhost:3000/.
 
-## Deploy Niginx with a generic app template
+## Deploy Nginx with a generic app template
 
 For the first portion of the demo, we’ll deploy Nginx using Cyclops.
 


### PR DESCRIPTION
## 📑 Description
Fix a minor typo in "Cyclops: Platform Engineering for the Rest of Us"
`niginx` to `nginx`

## ✅ Checks
- [x] I have tested my code (provide screenshots or screen recordings of a working solution)
- [x] I have performed a self-review of my code

## ℹ Additional context
