### PR TITLE
Make manifest modals share the same viewer

### DIFF
--- a/cyclops-ui/src/components/k8s-resources/ResourceList/ResourceList.tsx
+++ b/cyclops-ui/src/components/k8s-resources/ResourceList/ResourceList.tsx
@@ -13,7 +13,6 @@ import {
   Modal,
   Alert,
 } from "antd";
-import ReactAce from "react-ace";
 import {
   isWorkload,
   ResourceRef,
@@ -35,7 +34,6 @@ import NetworkPolicy from "../NetworkPolicy";
 
 import {
   CaretRightOutlined,
-  CopyOutlined,
   FileTextOutlined,
   FilterOutlined,
   WarningTwoTone,
@@ -54,6 +52,7 @@ import {
   ErrorIcon,
   WarningIcon,
 } from "../../status/icons";
+import ManifestContent from "../../shared/ManifestContent/ManifestContent";
 
 interface Props {
   loadResources: boolean;
@@ -105,6 +104,7 @@ const ResourceList = ({
   const [deleteResourceVerify, setDeleteResourceVerify] = useState("");
 
   const [showManagedFields, setShowManagedFields] = useState(false);
+  const [loadingResourceManifest, setLoadingResourceManifest] = useState(false);
 
   const [resourceFilter, setResourceFilter] = useState<string[]>([]);
   const [activeCollapses, setActiveCollapses] = useState(new Map());
@@ -181,6 +181,7 @@ const ResourceList = ({
     name: string,
     showManagedFields: boolean,
   ) => {
+    setLoadingResourceManifest(true);
     fetchResourceManifest(
       group,
       version,
@@ -194,9 +195,11 @@ const ResourceList = ({
           ...prev,
           manifest: res,
         }));
+        setLoadingResourceManifest(false);
       })
       .catch((error) => {
         setError(mapResponseError(error));
+        setLoadingResourceManifest(false);
       });
   };
 
@@ -740,42 +743,18 @@ const ResourceList = ({
       <Modal
         title="Manifest"
         open={manifestModal.on}
-        onOk={handleCancelManifest}
         onCancel={handleCancelManifest}
-        cancelButtonProps={{ style: { display: "none" } }}
+        footer={null}
         width={"70%"}
       >
         <Checkbox onChange={handleCheckboxChange} checked={showManagedFields}>
           Include Managed Fields
         </Checkbox>
-        <Divider style={{ marginTop: "12px", marginBottom: "12px" }} />
-        <div style={{ position: "relative" }}>
-          <ReactAce
-            style={{ width: "100%" }}
-            mode={"sass"}
-            theme={mode === "light" ? "github" : "twilight"}
-            value={manifestModal.manifest}
-            readOnly={true}
-          />
-          <Tooltip title={"Copy Manifest"} trigger="hover">
-            <Button
-              onClick={() => {
-                navigator.clipboard.writeText(manifestModal.manifest);
-              }}
-              style={{
-                position: "absolute",
-                right: "20px",
-                top: "10px",
-              }}
-            >
-              <CopyOutlined
-                style={{
-                  fontSize: "20px",
-                }}
-              />
-            </Button>
-          </Tooltip>
-        </div>
+        <ManifestContent
+          content={manifestModal.manifest}
+          loading={loadingResourceManifest}
+          mode={mode}
+        />
       </Modal>
       <Modal
         title={

--- a/cyclops-ui/src/components/shared/ManifestContent/ManifestContent.tsx
+++ b/cyclops-ui/src/components/shared/ManifestContent/ManifestContent.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Button, Divider, Spin, Tooltip } from "antd";
+import { CopyOutlined } from "@ant-design/icons";
+import "ace-builds/src-noconflict/mode-sass";
+import "ace-builds/src-noconflict/theme-github";
+import "ace-builds/src-noconflict/theme-twilight";
+import ReactAce from "react-ace";
+
+interface Props {
+  content: string;
+  loading: boolean;
+  mode: "light" | "dark";
+}
+
+const ManifestContent = ({ content, loading, mode }: Props) => {
+  if (loading) {
+    return <Spin />;
+  }
+
+  return (
+    <div>
+      <Divider />
+      <div style={{ position: "relative" }}>
+        <ReactAce
+          mode={"sass"}
+          theme={mode === "light" ? "github" : "twilight"}
+          fontSize={12}
+          showPrintMargin={true}
+          showGutter={true}
+          highlightActiveLine={true}
+          readOnly={true}
+          setOptions={{
+            enableBasicAutocompletion: true,
+            enableLiveAutocompletion: true,
+            enableSnippets: false,
+            showLineNumbers: true,
+            tabSize: 4,
+            useWorker: false,
+          }}
+          style={{
+            width: "100%",
+          }}
+          value={content}
+        />
+        <Tooltip title={"Copy manifest"} trigger="hover">
+          <Button
+            onClick={() => {
+              navigator.clipboard.writeText(content);
+            }}
+            style={{
+              position: "absolute",
+              right: "20px",
+              top: "10px",
+            }}
+          >
+            <CopyOutlined
+              style={{
+                fontSize: "20px",
+              }}
+            />
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  );
+};
+
+export default ManifestContent;

--- a/cyclops-ui/src/components/shared/ModuleResourceDetails/ModuleResourceDetails.tsx
+++ b/cyclops-ui/src/components/shared/ModuleResourceDetails/ModuleResourceDetails.tsx
@@ -20,7 +20,6 @@ import {
 import "ace-builds/src-noconflict/ace";
 import {
   BookOutlined,
-  CopyOutlined,
   DeleteOutlined,
   EditOutlined,
   FileTextOutlined,
@@ -30,7 +29,6 @@ import {
 import "./custom.css";
 
 import "ace-builds/src-noconflict/mode-jsx";
-import ReactAce from "react-ace";
 
 import { mapResponseError } from "../../../utils/api/errors";
 import ResourceList from "../../k8s-resources/ResourceList/ResourceList";
@@ -57,6 +55,7 @@ import {
   moduleConfigGitRefLink,
 } from "../../../utils/moduleConfigGitRef";
 import ModuleTitle from "./ModuleTitle/ModuleTitle";
+import ManifestContent from "../ManifestContent/ManifestContent";
 
 const languages = [
   "javascript",
@@ -656,59 +655,6 @@ export const ModuleResourceDetails = ({
       });
   };
 
-  const moduleManifestContent = (content: string, loading: boolean) => {
-    if (loading) {
-      return <Spin />;
-    }
-
-    return (
-      <div>
-        <Divider />
-        <div style={{ position: "relative" }}>
-          <ReactAce
-            mode={"sass"}
-            theme={mode === "light" ? "github" : "twilight"}
-            fontSize={12}
-            showPrintMargin={true}
-            showGutter={true}
-            highlightActiveLine={true}
-            readOnly={true}
-            setOptions={{
-              enableBasicAutocompletion: true,
-              enableLiveAutocompletion: true,
-              enableSnippets: false,
-              showLineNumbers: true,
-              tabSize: 4,
-              useWorker: false,
-            }}
-            style={{
-              width: "100%",
-            }}
-            value={content}
-          />
-          <Tooltip title={"Copy manifest"} trigger="hover">
-            <Button
-              onClick={() => {
-                navigator.clipboard.writeText(content);
-              }}
-              style={{
-                position: "absolute",
-                right: "20px",
-                top: "10px",
-              }}
-            >
-              <CopyOutlined
-                style={{
-                  fontSize: "20px",
-                }}
-              />
-            </Button>
-          </Tooltip>
-        </div>
-      </div>
-    );
-  };
-
   const gitConfigRedirectButton = () => {
     if (!module.gitOpsWrite) {
       return;
@@ -908,22 +854,28 @@ export const ModuleResourceDetails = ({
         <Modal
           title="Module manifest"
           open={viewRawManifest}
-          onOk={() => setViewRawManifest(false)}
           onCancel={() => setViewRawManifest(false)}
-          cancelButtonProps={{ style: { display: "none" } }}
+          footer={null}
           width={"70%"}
         >
-          {moduleManifestContent(rawModuleManifest, loadingRawManifest)}
+          <ManifestContent
+            content={rawModuleManifest}
+            loading={loadingRawManifest}
+            mode={mode}
+          />
         </Modal>
         <Modal
           title="Rendered manifest"
           open={viewRenderedManifest}
-          onOk={() => setViewRenderedManifest(false)}
           onCancel={() => setViewRenderedManifest(false)}
-          cancelButtonProps={{ style: { display: "none" } }}
+          footer={null}
           width={"70%"}
         >
-          {moduleManifestContent(renderedManifest, loadingRenderedManifest)}
+          <ManifestContent
+            content={renderedManifest}
+            loading={loadingRenderedManifest}
+            mode={mode}
+          />
         </Modal>
       </ConfigProvider>
     </div>


### PR DESCRIPTION
closes #641

## Description
- add a shared manifest viewer component for the Ace editor, copy button, theme, and loading state
- use the shared viewer for module, rendered, and resource manifest modals
- add loadingResourceManifest while fetching resource manifests and remove the default OK footer from manifest modals

## Checks
- [x] npx --yes prettier@3.2.5 --check src/components/shared/ManifestContent/ManifestContent.tsx src/components/shared/ModuleResourceDetails/ModuleResourceDetails.tsx src/components/k8s-resources/ResourceList/ResourceList.tsx
- [x] npx --yes esbuild@0.24.0 src/components/shared/ManifestContent/ManifestContent.tsx src/components/shared/ModuleResourceDetails/ModuleResourceDetails.tsx src/components/k8s-resources/ResourceList/ResourceList.tsx --loader:.tsx=tsx --format=esm --outdir=../../evidence/esbuild-check --log-level=warning
- [x] .\node_modules\.bin\react-scripts.cmd build (compiled; existing source-map warnings from @microsoft/fetch-event-source)
